### PR TITLE
Resolve issue null SystemCreatedAt Timezone Offset

### DIFF
--- a/businessCentral/src/ADLSEUtil.Codeunit.al
+++ b/businessCentral/src/ADLSEUtil.Codeunit.al
@@ -122,6 +122,15 @@ codeunit 82564 "ADLSE Util"
         end;
     end;
 
+    procedure GetUtcEpochWithTimezoneOffset(): DateTime
+    var
+        TypeHelper: Codeunit "Type Helper";
+        UtcOffset: Duration;
+    begin
+        TypeHelper.GetUserTimezoneOffset(UtcOffset);
+        exit(CreateDateTime(DMY2Date(1, 1, 1900), 0T) + UtcOffset);
+    end;
+
     procedure GetTableCaption(TableID: Integer): Text
     var
         RecRef: RecordRef;


### PR DESCRIPTION
When setting a Time Zone outside the UTC, the records with a null SystemCreatedAt receives a wrong DateTime.

![image](https://github.com/Bertverbeek4PS/bc2adls/assets/44637996/384579f8-f95a-45d1-8442-5e70bd4cd5da)
![image](https://github.com/Bertverbeek4PS/bc2adls/assets/44637996/24bb507a-2753-47dc-89a0-32add6b634a3)

 This PR append the offset of the Time Zone, so when this value gets converted back to UTC further on in the process , it's has the right value of 01 jan 1900.
```AL
    local procedure ConvertDateTimeToText(Val: DateTime) Result: Text
    ...
    begin
        // get default formatted as UTC
        Result := Format(Val, 0, 9); // The default formatting excludes the zeroes for the millseconds to the right.
```