### PR TITLE
Add permissions

### DIFF
--- a/businessCentral/permissions/ADLSETrackDelete.PermissionSet.al
+++ b/businessCentral/permissions/ADLSETrackDelete.PermissionSet.al
@@ -9,5 +9,7 @@ permissionset 82562 "ADLSE - Track Delete"
     Assignable = true;
     Caption = 'Azure Data Lake Storage - Track Delete';
 
-    Permissions = tabledata "ADLSE Deleted Record" = I;
+    Permissions = tabledata "ADLSE Deleted Record" = I,
+                      table "ADLSE Table Last Timestamp" = X,
+                  tabledata "ADLSE Table Last Timestamp" = R;
 }


### PR DESCRIPTION
![image](https://github.com/Bertverbeek4PS/bc2adls/assets/44637996/451cd838-ec50-4550-bf0d-bace291740dd)

In the ```OnAfterOnDatabaseDelete``` method the user also need read and execute permissions on the "ADLSE Table Last Timestamp" record, see the error message (in Dutch) above.

```AL
    [EventSubscriber(ObjectType::Codeunit, Codeunit::GlobalTriggerManagement, 'OnAfterOnDatabaseDelete', '', true, true)]
    local procedure OnAfterOnDatabaseDelete(RecRef: RecordRef)
    var
        ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
        ADLSEDeletedRecord: Record "ADLSE Deleted Record";
    begin
        // exit function for tables that you do not wish to sync deletes for
        // you should also consider not registering for deletes for the table in the function GetDatabaseTableTriggerSetup above.
        // if RecRef.Number = Database::"G/L Entry" then
        //     exit;

        // check if table is to be tracked.
        if not ADLSETableLastTimestamp.ExistsUpdatedLastTimestamp(RecRef.Number) then
            exit;

        ADLSEDeletedRecord.TrackDeletedRecord(RecRef);
    end;
```