### PR TITLE
Set position on AddBlockToDataBlob

### DIFF
--- a/businessCentral/src/ADLSEHttpMethod.Enum.al
+++ b/businessCentral/src/ADLSEHttpMethod.Enum.al
@@ -9,4 +9,5 @@ enum 82561 "ADLSE Http Method"
     value(1; Put) { }
     value(2; Delete) { }
     value(3; Patch) { }
+    value(4; Head) { }
 }


### PR DESCRIPTION
When exporting a delta larger then the "Max playload size (MiBs)” setting, an error occurs.

![image](https://github.com/Bertverbeek4PS/bc2adls/assets/44637996/f46ddf61-9314-42fd-9a6a-da617c0cce40)

I've try'ed to keep the size of the payload in runtime after each call, but then on larger files (80MB+) a mismatch eventually occurs. To be 100% sure, retrieve the current size of the file before append and flush. With a HEAD (in stead of GET) it should be not much of a performance penalty?

Tested it up to almost a 2 GB file
![image](https://github.com/Bertverbeek4PS/bc2adls/assets/44637996/46079713-bf25-43c6-9fb5-b0115a301734)
