### PR TITLE
Remove Line feed and Carriage Return from String

### DIFF
--- a/businessCentral/src/ADLSEUtil.Codeunit.al
+++ b/businessCentral/src/ADLSEUtil.Codeunit.al
@@ -236,7 +236,14 @@ codeunit 82564 "ADLSE Util"
     end;
 
     local procedure ConvertStringToText(Val: Text): Text
+    var
+        Char10, Char13 : Char;
     begin
+        Char10 := 10; // Line feed - '\n'
+        Char13 := 13; // Carriage return - '\r'
+
+        Val := Val.Replace(Char10, ' '); // remove the Line feed - '\n' character
+        Val := Val.Replace(Char13, ' '); // remove the Carriage return - '\r' character
         Val := Val.Replace('\', '\\'); // escape the escape character
         Val := Val.Replace('"', '\"'); // escape the quote character
         exit(StrSubstNo(QuotedTextTok, Val));


### PR DESCRIPTION
Apparent users still somehow manage to add data in Business Central with Line feeds and/or Carriage Returns.

This results in strange records in the Lakehouse, so replacing them with a single space character.

![image](https://github.com/Bertverbeek4PS/bc2adls/assets/44637996/d8f17a15-767a-42f5-b3bf-f9f90f8b4c75)
