### PR TITLE
Fix to Account Name Validation

### DIFF
--- a/businessCentral/src/ADLSESetup.Table.al
+++ b/businessCentral/src/ADLSESetup.Table.al
@@ -23,7 +23,7 @@ table 82560 "ADLSE Setup"
             begin
                 // Name constraints based on https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#storage-account-name
                 if (StrLen(Rec."Account Name") < 3) or (StrLen(Rec."Account Name") > 24) // between 3 and 24 characters long
-                    or TextCharactersOtherThan(Container, 'abcdefghijklmnopqrstuvwxyz1234567890') // only made of lower case letters and numerals
+                    or TextCharactersOtherThan(Rec."Account Name", 'abcdefghijklmnopqrstuvwxyz1234567890') // only made of lower case letters and numerals
                 then
                     Error(AccountNameIncorrectFormatErr);
             end;


### PR DESCRIPTION
Account Name validation incorrectly references "Container" rather than Rec."Account Name" so validation fails if there is a '-' in the container name.