### PR TITLE
Fix for Invalid URL Error in BaseURL

### DIFF
--- a/businessCentral/src/ADLSECommunication.Codeunit.al
+++ b/businessCentral/src/ADLSECommunication.Codeunit.al
@@ -45,8 +45,8 @@ codeunit 82562 "ADLSE Communication"
     var
         ADLSESetup: Record "ADLSE Setup";
     begin
-        if DefaultContainerName = '' then begin
-            ADLSESetup.GetSingleton();
+        ADLSESetup.GetSingleton();
+        if DefaultContainerName = '' then begin         
             DefaultContainerName := ADLSESetup.Container;
         end;
         exit(StrSubstNo(ContainerUrlTxt, ADLSESetup."Account Name", DefaultContainerName));


### PR DESCRIPTION
On second and subsequent calls to GetBaseURL the value for ADSLESetup."Account Name" is NULL due to ADSLE Setup not being initialized to the setup record. The call to GetSingleton() has been moved to fix this. This was causing loads to hang at "In Process" on submission of jobs.