### PR TITLE
Tables per company fix export

### DIFF
--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -14,7 +14,6 @@ codeunit 82561 "ADLSE Execute"
         ADLSECommunication: Codeunit "ADLSE Communication";
         ADLSEExecution: Codeunit "ADLSE Execution";
         ADLSEUtil: Codeunit "ADLSE Util";
-        TypeHelper: Codeunit "Type Helper";
         CustomDimensions: Dictionary of [Text, Text];
         TableCaption: Text;
         UpdatedLastTimestamp: BigInteger;
@@ -44,10 +43,6 @@ codeunit 82561 "ADLSE Execute"
 
         UpdatedLastTimestamp := ADLSETableLastTimestamp.GetUpdatedLastTimestamp(Rec."Table ID");
         DeletedLastEntryNo := ADLSETableLastTimestamp.GetDeletedLastEntryNo(Rec."Table ID");
-
-        if not ADLSEUtil.IsTablePerCompany(Rec."Table ID") then
-            if (TypeHelper.EvaluateUnixTimestamp(UpdatedLastTimestamp) - CurrentDateTime) < 600000 then
-                exit;
 
         if EmitTelemetry then begin
             CustomDimensions.Add('Old Updated Last time stamp', Format(UpdatedLastTimestamp));

--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -14,6 +14,7 @@ codeunit 82561 "ADLSE Execute"
         ADLSECommunication: Codeunit "ADLSE Communication";
         ADLSEExecution: Codeunit "ADLSE Execution";
         ADLSEUtil: Codeunit "ADLSE Util";
+        TypeHelper: Codeunit "Type Helper";
         CustomDimensions: Dictionary of [Text, Text];
         TableCaption: Text;
         UpdatedLastTimestamp: BigInteger;
@@ -43,6 +44,10 @@ codeunit 82561 "ADLSE Execute"
 
         UpdatedLastTimestamp := ADLSETableLastTimestamp.GetUpdatedLastTimestamp(Rec."Table ID");
         DeletedLastEntryNo := ADLSETableLastTimestamp.GetDeletedLastEntryNo(Rec."Table ID");
+
+        if not ADLSEUtil.IsTablePerCompany(Rec."Table ID") then
+            if (TypeHelper.EvaluateUnixTimestamp(UpdatedLastTimestamp) - CurrentDateTime) < 600000 then
+                exit;
 
         if EmitTelemetry then begin
             CustomDimensions.Add('Old Updated Last time stamp', Format(UpdatedLastTimestamp));

--- a/businessCentral/app/src/SessionManager.Codeunit.al
+++ b/businessCentral/app/src/SessionManager.Codeunit.al
@@ -27,6 +27,7 @@ codeunit 82570 "ADLSE Session Manager"
     local procedure StartExport(TableID: Integer; ExportWasPending: Boolean; ForceExport: Boolean; EmitTelemetry: Boolean) Started: Boolean
     var
         ADLSETable: Record "ADLSE Table";
+        ADLSESetup: Record "ADLSE Setup";
         ADLSEExecution: Codeunit "ADLSE Execution";
         ADLSEUtil: Codeunit "ADLSE Util";
         CustomDimensions: Dictionary of [Text, Text];
@@ -34,6 +35,13 @@ codeunit 82570 "ADLSE Session Manager"
     begin
         if ForceExport or DataChangesExist(TableID) then begin
             ADLSETable.Get(TableID);
+
+            ADLSESetup.GetSingleton();
+            if ADLSESetup."Export Company Database Tables" <> '' then
+                if (not ADLSEUtil.IsTablePerCompany(TableID)) then
+                    if (ADLSESetup."Export Company Database Tables" <> CompanyName()) then
+                        exit;
+
             Started := Session.StartSession(NewSessionID, Codeunit::"ADLSE Execute", CompanyName(), ADLSETable);
             CustomDimensions.Add('Entity', ADLSEUtil.GetTableCaption(TableID));
             CustomDimensions.Add('ExportWasPending', Format(ExportWasPending));

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -157,6 +157,11 @@ page 82560 "ADLSE Setup"
                     {
                         ToolTip = 'Specifies if the column DeliveredDateTime will be added to the CSV export file.';
                     }
+                    field("Export Company Database Tables"; Rec."Export Company Database Tables")
+                    {
+                        ToolTip = 'Specifies the company for the export of the database tables.';
+                        Lookup = true;
+                    }
                 }
             }
             part(Tables; "ADLSE Setup Tables")

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -153,6 +153,13 @@ table 82560 "ADLSE Setup"
         {
             Caption = 'Add delivered DateTime';
         }
+        //Add field for lookup to table companies
+        field(65; "Export Company Database Tables"; Text[30])
+        {
+            Caption = 'Export Company Database Tables';
+            TableRelation = Company.Name;
+        }
+
     }
 
     keys


### PR DESCRIPTION
Now you can set a company which you want to export the tables per database. 
In that case you only export one time and not everytime.
If you leave it empty it is as is.