### PR TITLE
Fix Bytes to be written to the stream exceed the Content-Length bytes size specified.

### DIFF
--- a/businessCentral/app/src/Http.Codeunit.al
+++ b/businessCentral/app/src/Http.Codeunit.al
@@ -168,7 +168,11 @@ codeunit 82563 "ADLSE Http"
         ADLSESetup: Record "ADLSE Setup";
         Headers: HttpHeaders;
     begin
-        HttpContent.WriteFrom(Body);
+        if (ADLSESetup.GetStorageType() = ADLSESetup."Storage Type"::"Azure Data Lake") or
+        (ADLSESetup.GetStorageType() = ADLSESetup."Storage Type"::"Microsoft Fabric") and (not ContentTypeJson)
+        then
+            HttpContent.WriteFrom(Body);
+
         HttpContent.GetHeaders(Headers);
 
         if ContentTypeJson then begin


### PR DESCRIPTION
This pull request fix the error on bc24 and sometimes bc23 if you get the error:
"Bytes to be written to the stream exceed the Content-Length bytes size specified"
Now when creating the content for the schema the body must not be send.