### PR TITLE
Fix dead lock adls table on reset

### DIFF
--- a/businessCentral/app/src/Setup.Codeunit.al
+++ b/businessCentral/app/src/Setup.Codeunit.al
@@ -17,6 +17,7 @@ codeunit 82560 "ADLSE Setup"
         AllObjectsWithCaption: Page "All Objects with Caption";
     begin
         AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
+        AllObjWithCaption.SetFilter("Object ID", '<>%1', Database::"ADLSE Deleted Record");
 
         AllObjectsWithCaption.Caption(SelectTableLbl);
         AllObjectsWithCaption.SetTableView(AllObjWithCaption);

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -28,7 +28,12 @@ table 82561 "ADLSE Table"
             trigger OnValidate()
             var
                 ADLSEExternalEvents: Codeunit "ADLSE External Events";
+                ADLSETableErr: Label 'The ADLSE Table table cannot be disabled.';
             begin
+                if Rec."Table ID" = Database::"ADLSE Table" then
+                    if xRec.Enabled = false then
+                        Error(ADLSETableErr);
+
                 if Rec.Enabled then
                     CheckExportingOnlyValidFields();
 
@@ -176,8 +181,10 @@ table 82561 "ADLSE Table"
     begin
         if Rec.FindSet(true) then
             repeat
-                Rec.Enabled := true;
-                Rec.Modify();
+                if not Rec.Enabled then begin
+                    Rec.Enabled := true;
+                    Rec.Modify();
+                end;
 
                 ADLSETableLastTimestamp.SaveUpdatedLastTimestamp(Rec."Table ID", 0);
                 ADLSETableLastTimestamp.SaveDeletedLastEntryNo(Rec."Table ID", 0);


### PR DESCRIPTION
You cannot add the deleted records table anymore and fixed the deadlock.