### PR TITLE
Adds Environment column to exported data

### DIFF
--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -8,6 +8,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
         BlankArray: JsonArray;
         CompanyFieldNameLbl: Label '$Company';
         DeliveredDateTimeFieldNameLbl: Label '$DeliveredDateTime';
+        EnvironmentFieldNameLbl: Label '$Environment';
         ExistingFieldCannotBeRemovedErr: Label 'The field %1 in the entity %2 is already present in the data lake and cannot be removed.', Comment = '%1: field name, %2: entity name';
         FieldDataTypeCannotBeChangedErr: Label 'The data type for the field %1 in the entity %2 cannot be changed.', Comment = '%1: field name, %2: entity name';
         RepresentsTableTxt: Label 'Represents the table %1', Comment = '%1: table caption';
@@ -139,16 +140,26 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
             Result.Add(
                 CreateAttributeJson(GetDeliveredDateTimeFieldName(), DataFormat, GetDeliveredDateTimeFieldName(), AppliedTraits, FieldRef.Length));
         end;
+
         if ADLSEUtil.IsTablePerCompany(TableID) then begin
             GetCDMAttributeDetails(FieldType::Text, DataFormat, AppliedTraits);
             Result.Add(
                 CreateAttributeJson(GetCompanyFieldName(), DataFormat, GetCompanyFieldName(), AppliedTraits, FieldRef.Length));
         end;
+
+        GetCDMAttributeDetails(FieldType::Text, DataFormat, AppliedTraits);
+        Result.Add(
+            CreateAttributeJson(GetEnvironmentFieldName(), DataFormat, GetEnvironmentFieldName(), AppliedTraits, FieldRef.Length));
     end;
 
     procedure GetCompanyFieldName(): Text
     begin
         exit(CompanyFieldNameLbl);
+    end;
+
+    procedure GetEnvironmentFieldName(): Text
+    begin
+        exit(EnvironmentFieldNameLbl);
     end;
 
     procedure GetDeliveredDateTimeFieldName(): Text

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -334,11 +334,17 @@ codeunit 82564 "ADLSE Util"
         end;
         if IsTablePerCompany(RecordRef.Number) then
             Payload.Append(StrSubstNo(CommaPrefixedTok, ADLSECDMUtil.GetCompanyFieldName()));
+
+        Payload.Append(StrSubstNo(CommaPrefixedTok, ADLSECDMUtil.GetEnvironmentFieldName()));
+
         ADLSESetup.GetSingleton();
         if ADLSESetup."Delivered DateTime" then
             Payload.Append(StrSubstNo(CommaPrefixedTok, ADLSECDMUtil.GetDeliveredDateTimeFieldName()));
+
+
         Payload.AppendLine();
         RecordPayload := Payload.ToText();
+
     end;
 
     procedure CreateCsvPayload(RecordRef: RecordRef; FieldIdList: List of [Integer]; AddHeaders: Boolean) RecordPayload: Text
@@ -371,11 +377,22 @@ codeunit 82564 "ADLSE Util"
         end;
         if IsTablePerCompany(RecordRef.Number) then
             Payload.Append(StrSubstNo(CommaPrefixedTok, ConvertStringToText(CompanyName())));
+
+        Payload.Append(StrSubstNo(CommaPrefixedTok, ConvertStringToText(EnvironmentName())));
+
         if ADLSESetup."Delivered DateTime" then
             Payload.Append(StrSubstNo(CommaPrefixedTok, ConvertDateTimeToText(CurrDateTime)));
+
         Payload.AppendLine();
 
         RecordPayload := Payload.ToText();
+    end;
+
+    procedure EnvironmentName(): Text
+    var
+        EnvironmentInformation: Codeunit "Environment Information";
+    begin
+        exit(EnvironmentInformation.GetEnvironmentName());
     end;
 
     procedure IsTablePerCompany(TableID: Integer): Boolean


### PR DESCRIPTION
Hi @Bertverbeek4PS, first all of thank you for keeping the project alive and maintaining it!

We are currently using bc2adls for a couple of our customers where we have the requirement to extract data from multiple companies and environments and consolidate it across them all.
Therefore we simply added a $Environment column to the exported data.
Even if our requirement might not be that common I still consider this a good addition without any drawbacks.
I also considered simply editing the CopyBusinessCentral notebook to add the environment name by passing it via a parameter, but I think it's cleaner this way.

A little extra info:
I am aware that it is recommended to export data from different environments to different lakes, but we opted to not do it because it will involve creating additional pipelines/notebooks/sjd to handle the consolidation. To solve this instead I modified the CopyBusinessCentral notebook to handle data from multiple environments coming into the same lake. I didn't add it to the PR because it might not be relevant for everyone, but can do so if people might find it useful.