### PR TITLE
Add functionality to remove delta files when resetting tables

### DIFF
--- a/businessCentral/app/src/Communication.Codeunit.al
+++ b/businessCentral/app/src/Communication.Codeunit.al
@@ -361,11 +361,20 @@ codeunit 82562 "ADLSE Communication"
 
     procedure ResetTableExport(ltableId: Integer)
     var
+        ADLSESetup: Record "ADLSE Setup";
         ADLSEUtil: Codeunit "ADLSE Util";
         ADLSEGen2Util: Codeunit "ADLSE Gen 2 Util";
         Body: JsonObject;
     begin
+        ADLSESetup.GetSingleton();
         ADLSECredentials.Init();
-        ADLSEGen2Util.CreateOrUpdateJsonBlob(GetBaseUrl() + StrSubstNo(ResetTableExportTxt, ADLSEUtil.GetDataLakeCompliantTableName(ltableId)), ADLSECredentials, '', Body);
+        case ADLSESetup."Storage Type" of
+            "ADLSE Storage Type"::"Microsoft Fabric":
+                ADLSEGen2Util.CreateOrUpdateJsonBlob(GetBaseUrl() + StrSubstNo(ResetTableExportTxt, ADLSEUtil.GetDataLakeCompliantTableName(ltableId)), ADLSECredentials, '', Body);
+            "ADLSE Storage Type"::"Azure Data Lake":
+                ADLSEGen2Util.RemoveDeltasFromDataLake(ADLSEUtil.GetDataLakeCompliantTableName(ltableId), ADLSECredentials);
+        end;
     end;
+
+
 }

--- a/businessCentral/app/src/Gen2Util.Codeunit.al
+++ b/businessCentral/app/src/Gen2Util.Codeunit.al
@@ -296,6 +296,26 @@ codeunit 82568 "ADLSE Gen 2 Util"
         exit(true);
     end;
 
+    procedure RemoveDeltasFromDataLake(ADLSEntityName: Text; ADLSECredentials: Codeunit "ADLSE Credentials")
+    var
+        ADLSESetup: Record "ADLSE Setup";
+        ADLSEHttp: Codeunit "ADLSE Http";
+        Response: Text;
+        Url: Text;
+        ADLSEContainerUrlTxt: Label 'https://%1.dfs.core.windows.net/%2', Comment = '%1: Account name, %2: Container Name', Locked = true;
+    begin
+        // DELETE https://{accountName}.{dnsSuffix}/{filesystem}/{path}
+        // https://learn.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete?view=rest-storageservices-datalakestoragegen2-2019-12-12
+        ADLSESetup.GetSingleton();
+        Url := StrSubstNo(ADLSEContainerUrlTxt, ADLSESetup."Account Name", ADLSESetup.Container);
+        Url += '/deltas/' + ADLSEntityName + '?recursive=true';
+
+        ADLSEHttp.SetMethod("ADLSE Http Method"::Delete);
+        ADLSEHttp.SetUrl(Url);
+        ADLSEHttp.SetAuthorizationCredentials(ADLSECredentials);
+        ADLSEHttp.InvokeRestApi(Response)
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnBeforeGetBlobContent(BlobPath: Text; ADLSECredentials: Codeunit "ADLSE Credentials"; var BlobExists: Boolean; var Content: JsonObject; var IsHandled: Boolean)
     begin

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -151,7 +151,6 @@ page 82560 "ADLSE Setup"
                     field("Delete Table"; Rec."Delete Table")
                     {
                         ToolTip = 'Specifies if the table will be deleted if a reset of the table is done.';
-                        Editable = not AzureDataLake;
                     }
                     field("Delivered DateTime"; Rec."Delivered DateTime")
                     {

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -193,7 +193,7 @@ table 82561 "ADLSE Table"
                 ADLSEDeletedRecord.DeleteAll();
 
                 ADLSESetup.GetSingleton();
-                if (ADLSESetup."Delete Table") and (ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Microsoft Fabric") then
+                if (ADLSESetup."Delete Table") then
                     ADLSECommunication.ResetTableExport(Rec."Table ID");
 
                 OnAfterResetSelected(Rec);


### PR DESCRIPTION
We were running into a problem with our azure data factory. It can not handle changes in the data model, while not all deltas have been processed yet. So we either (1) need to avoid datamodel changes while we have still have deltas or (2) remove the existing deltas.  
Looking to towards the code, for Microsoft Fabric Storage Type  a functionality simular to the second option is already present. This pull request extends the functionality for deleting tables with the handling of Azure Data Lake.  