### PR TITLE
Add functionality to automatic check the addition of all primary key …

### DIFF
--- a/businessCentral/app/src/Field.Table.al
+++ b/businessCentral/app/src/Field.Table.al
@@ -45,6 +45,9 @@ table 82562 "ADLSE Field"
                 if Rec.Enabled then
                     Rec.CheckFieldToBeEnabled();
 
+                if not Rec.Enabled then
+                    Rec.CheckNotPrimaryKeyField();
+
                 ADLSEExternalEvents.OnEnableFieldChanged(Rec);
             end;
         }
@@ -123,6 +126,17 @@ table 82562 "ADLSE Field"
         Field.Get(Rec."Table ID", Rec."Field ID");
         ADLSEUtil.CheckFieldTypeForExport(Field);
         ADLSESetup.CheckFieldCanBeExported(Field);
+    end;
+
+    procedure CheckNotPrimaryKeyField()
+    var
+        Field: Record Field;
+        FieldCannotBeDisabledErr: Label 'Table field is part of the Primary Key, Field cannot be disabled.';
+    begin
+        if Rec.Enabled then exit;
+        if not Field.Get(Rec."Table ID", Rec."Field ID") then exit;
+        if Field.IsPartOfPrimaryKey then
+            error(FieldCannotBeDisabledErr)
     end;
 
     [TryFunction]

--- a/businessCentral/app/src/SetupFields.Page.al
+++ b/businessCentral/app/src/SetupFields.Page.al
@@ -17,19 +17,34 @@ page 82562 "ADLSE Setup Fields"
         {
             repeater(GroupName)
             {
-                field("FieldCaption"; Rec.FieldCaption) { }
+                field("FieldCaption"; Rec.FieldCaption) 
+		{ 
+                    StyleExpr = StyleExprAsText;
+		}
 
                 field("Field ID"; Rec."Field ID")
                 {
                     Caption = 'Number';
+                    StyleExpr = StyleExprAsText;
                     Visible = false;
                 }
 
-                field(Enabled; Rec.Enabled) { }
-
+                field(Enabled; Rec.Enabled) 
+		{ 
+                    StyleExpr = StyleExprAsText;
+		}
+                field(IsPartOfPrimaryKey; IsPartOfPrimaryKey)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Part of Primary Key';
+                    Editable = false;
+                    StyleExpr = StyleExprAsText;
+                    ToolTip = 'Specifies if the the field is part of the primary key';
+                }
                 field(ADLSFieldName; ADLSFieldName)
                 {
                     Caption = 'Attribute name';
+                    StyleExpr = StyleExprAsText;
                     ToolTip = 'Specifies the name of the field for this entity in the data lake.';
                     Editable = false;
                 }
@@ -38,6 +53,7 @@ page 82562 "ADLSE Setup Fields"
                 {
                     Caption = 'Class';
                     OptionCaption = 'Normal,FlowField,FlowFilter';
+                    StyleExpr = StyleExprAsText;
                     ToolTip = 'Specifies the field class.';
                     Editable = false;
                     Visible = false;
@@ -105,10 +121,17 @@ page 82562 "ADLSE Setup Fields"
         FieldClassName := Field.Class;
         FieldTypeName := Field."Type Name";
         FieldObsoleteState := Field.ObsoleteState;
+        IsPartOfPrimaryKey := Field.IsPartOfPrimaryKey;
+        if IsPartOfPrimaryKey then
+            StyleExprAsText := 'StrongAccent'
+        else
+            StyleExprAsText := 'Standard';
     end;
 
     var
+        IsPartOfPrimaryKey: Boolean;
         ADLSFieldName: Text;
+        StyleExprAsText: Text;
         FieldClassName: Option Normal,FlowField,FlowFilter;
         FieldTypeName: Text[30];
         SomeFieldsCouldNotBeEnabledMsg: Label 'One or more fields could not be enabled.';

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -134,6 +134,7 @@ table 82561 "ADLSE Table"
         Rec.Enabled := true;
         Rec.Insert(true);
 
+        AddPrimaryKeyFields();
         ADLSEExternalEvents.OnAddTable(Rec);
     end;
 
@@ -275,6 +276,23 @@ table 82561 "ADLSE Table"
             until ADLSEFields.Next() = 0;
     end;
 
+    local procedure AddPrimaryKeyFields()
+    var
+        Field: Record Field;
+        ADLSEField: Record "ADLSE Field";
+    begin
+        Field.SetRange(TableNo, Rec."Table ID");
+        Field.SetRange(IsPartOfPrimaryKey, true);
+        if Field.Findset() then
+            repeat
+                if not ADLSEField.Get(Rec."Table ID", Field."No.") then begin
+                    ADLSEField."Table ID" := Field.TableNo;
+                    ADLSEField."Field ID" := Field."No.";
+                    ADLSEField.Enabled := true;
+                    ADLSEField.Insert();
+                end;
+            until Field.Next() = 0;
+    end;
     [IntegrationEvent(false, false)]
     local procedure OnAfterResetSelected(ADLSETable: Record "ADLSE Table")
     begin


### PR DESCRIPTION
We have recently added the functionality to ensure the addition of the primary key fields on table export. We have performed this since we running into problems with our azure data factory when not all primary key fields were present on the table export. Additionally we highlighted the Index fields in the list of fields.

We think that this might be a nice addition to the community version as well. 

