### PR TITLE
Add functionality to have job queues with different schedules

### DIFF
--- a/businessCentral/app/permissions/Execute.PermissionSet.al
+++ b/businessCentral/app/permissions/Execute.PermissionSet.al
@@ -19,6 +19,7 @@ permissionset 82561 "ADLSE - Execute"
                   tabledata "ADLSE Enum Translation" = RIMD,
                   tabledata "ADLSE Enum Translation Lang" = RIMD,
                   tabledata "Deleted Tables Not to Sync" = R,
+                  tabledata "ADLSE Export Category" = R,
                   codeunit "ADLSE UpgradeTagNewCompanySubs" = X,
                   codeunit "ADLSE Upgrade" = X,
                   codeunit "ADLSE Util" = X,

--- a/businessCentral/app/permissions/Setup.PermissionSet.al
+++ b/businessCentral/app/permissions/Setup.PermissionSet.al
@@ -19,6 +19,7 @@ permissionset 82560 "ADLSE - Setup"
                   tabledata "ADLSE Enum Translation" = RIMD,
                   tabledata "ADLSE Enum Translation Lang" = RIMD,
                   tabledata "Deleted Tables Not to Sync" = RIMD,
+                  tabledata "ADLSE Export Category" = RIMD,
                   codeunit "ADLSE Clear Tracked Deletions" = X,
                   codeunit "ADLSE Credentials" = X,
                   codeunit "ADLSE Setup" = X,
@@ -29,5 +30,8 @@ permissionset 82560 "ADLSE - Setup"
                   page "ADLSE Run" = X,
                   page "ADLSE Enum Translations" = X,
                   page "ADLSE Enum Translations Lang" = X,
+                  page "ADLSE Export Categories" = X,
+                  page "ADLSE Assign Export Category" = X,
+                  report "ADLSE Schedule Task Assignment" = X,
                   xmlport "BC2ADLS Import" = X;
 }

--- a/businessCentral/app/src/AssignExportCategoryDialog.page.al
+++ b/businessCentral/app/src/AssignExportCategoryDialog.page.al
@@ -1,0 +1,29 @@
+page 82576 "ADLSE Assign Export Category"
+{
+    ApplicationArea = Basic, Suite;
+    Caption = 'Assign Export Category';
+    PageType = StandardDialog;
+    DataCaptionExpression = '';
+    ModifyAllowed = false;
+
+    layout
+    {
+        area(Content)
+        {
+            field("Export Category"; ExportCategory)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Export Catgory';
+                TableRelation = "ADLSE Export Category".Code;
+                ToolTip = 'Unique Code of an Export Category which can be linked to tables which are part of the export to Azure Datalake.';
+            }
+        }
+    }
+    var
+        ExportCategory: code[50];
+
+    procedure GetExportCategoryCode(): Code[50]
+    begin
+        exit(ExportCategory);
+    end;
+}

--- a/businessCentral/app/src/AssignExportCategoryDialog.page.al
+++ b/businessCentral/app/src/AssignExportCategoryDialog.page.al
@@ -15,7 +15,7 @@ page 82576 "ADLSE Assign Export Category"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Export Catgory';
                 TableRelation = "ADLSE Export Category".Code;
-                ToolTip = 'Unique Code of an Export Category which can be linked to tables which are part of the export to Azure Datalake.';
+                ToolTip = 'Specifies Unique Code of an Export Category which can be linked to tables which are part of the export to Azure Datalake.';
             }
         }
     }

--- a/businessCentral/app/src/Execution.Codeunit.al
+++ b/businessCentral/app/src/Execution.Codeunit.al
@@ -146,23 +146,6 @@ codeunit 82569 "ADLSE Execution"
         ADLSEExternalEvents.OnClearSchemaExportedOn(ADLSESetup);
     end;
 
-    internal procedure ScheduleExport()
-    var
-        JobQueueEntry: Record "Job Queue Entry";
-        ScheduleAJob: Page "Schedule a Job";
-        Handled: Boolean;
-    begin
-        OnBeforeScheduleExport(Handled);
-        if Handled then
-            exit;
-
-        CreateJobQueueEntry(JobQueueEntry);
-        ScheduleAJob.SetJob(JobQueueEntry);
-        Commit(); // above changes go into the DB before RunModal
-        if ScheduleAJob.RunModal() = Action::OK then
-            Message(JobScheduledTxt);
-    end;
-
     local procedure CreateJobQueueEntry(var JobQueueEntry: Record "Job Queue Entry")
     var
         JobQueueCategory: Record "Job Queue Category";

--- a/businessCentral/app/src/Execution.Codeunit.al
+++ b/businessCentral/app/src/Execution.Codeunit.al
@@ -21,8 +21,16 @@ codeunit 82569 "ADLSE Execution"
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'r')]
     internal procedure StartExport()
     var
-        ADLSESetupRec: Record "ADLSE Setup";
         ADLSETable: Record "ADLSE Table";
+    begin
+        StartExport(AdlseTable);
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'r')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'r')]
+    internal procedure StartExport(var AdlseTable: Record "ADLSE Table")
+    var
+        ADLSESetupRec: Record "ADLSE Setup";
         ADLSEField: Record "ADLSE Field";
         ADLSECurrentSession: Record "ADLSE Current Session";
         ADLSESetup: Codeunit "ADLSE Setup";

--- a/businessCentral/app/src/ExportCategories.Page.al
+++ b/businessCentral/app/src/ExportCategories.Page.al
@@ -4,7 +4,6 @@ page 82577 "ADLSE Export Categories"
     Caption = 'Export Catgories';
     PageType = List;
     SourceTable = "ADLSE Export Category";
-    UsageCategory = Lists;
 
 
     layout
@@ -16,12 +15,10 @@ page 82577 "ADLSE Export Categories"
                 field(Code; Rec.Code)
                 {
                     Caption = 'Code';
-                    ToolTip = 'Unique Code of a Export Category which can be linked to tables which are part of the export to Azure Datalake.';
                 }
                 field(Description; Rec.Description)
                 {
                     Caption = 'Description';
-                    ToolTip = 'Description of the Export Category.';
                 }
             }
         }

--- a/businessCentral/app/src/ExportCategories.Page.al
+++ b/businessCentral/app/src/ExportCategories.Page.al
@@ -1,0 +1,30 @@
+page 82577 "ADLSE Export Categories"
+{
+    ApplicationArea = Basic, Suite;
+    Caption = 'Export Catgories';
+    PageType = List;
+    SourceTable = "ADLSE Export Category";
+    UsageCategory = Lists;
+
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(General)
+            {
+                field(Code; Rec.Code)
+                {
+                    Caption = 'Code';
+                    ToolTip = 'Unique Code of a Export Category which can be linked to tables which are part of the export to Azure Datalake.';
+                }
+                field(Description; Rec.Description)
+                {
+                    Caption = 'Description';
+                    ToolTip = 'Description of the Export Category.';
+                }
+            }
+        }
+    }
+}
+

--- a/businessCentral/app/src/ExportCategory.Table.al
+++ b/businessCentral/app/src/ExportCategory.Table.al
@@ -1,0 +1,27 @@
+table 82570 "ADLSE Export Category"
+{
+    Caption = 'Export Category';
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Code"; Code[50])
+        {
+            Caption = 'Code';
+            DataClassification = CustomerContent;
+        }
+        field(10; Description; Text[250])
+        {
+            Caption = 'Description';
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/businessCentral/app/src/ExportCategory.Table.al
+++ b/businessCentral/app/src/ExportCategory.Table.al
@@ -2,6 +2,7 @@ table 82570 "ADLSE Export Category"
 {
     Caption = 'Export Category';
     DataClassification = ToBeClassified;
+    LookupPageId = "ADLSE Export Categories";
 
     fields
     {
@@ -9,11 +10,13 @@ table 82570 "ADLSE Export Category"
         {
             Caption = 'Code';
             DataClassification = CustomerContent;
+            ToolTip = 'Specifies the Unique Code of a Export Category which can be linked to tables which are part of the export to Azure Datalake.';
         }
         field(10; Description; Text[250])
         {
             Caption = 'Description';
             DataClassification = CustomerContent;
+            ToolTip = 'Specifies the Description of the Export Category.';
         }
     }
     keys

--- a/businessCentral/app/src/ScheduleTaskAssignment.Report.al
+++ b/businessCentral/app/src/ScheduleTaskAssignment.Report.al
@@ -1,7 +1,7 @@
 report 82561 "ADLSE Schedule Task Assignment"
 {
     ApplicationArea = Basic, Suite;
-    Caption = 'Schedule Export to Azure Data Lake';
+    Caption = 'Schedule Export';
     ProcessingOnly = true;
 
 
@@ -37,7 +37,7 @@ report 82561 "ADLSE Schedule Task Assignment"
                     field(EarliestStartDateTimeControl; EarliestStartDateTime)
                     {
                         ApplicationArea = All;
-                        Caption = 'Earliest Start Dqate / Time ';
+                        Caption = 'Earliest Start Date / Time ';
                         ToolTip = 'Specifies the date and time when the job queue must be executed for the first time.';
                     }
                     field(NoofMinutesBetweeenRuns; NoofMinutesBetweenRuns)

--- a/businessCentral/app/src/ScheduleTaskAssignment.Report.al
+++ b/businessCentral/app/src/ScheduleTaskAssignment.Report.al
@@ -1,7 +1,7 @@
 report 82561 "ADLSE Schedule Task Assignment"
 {
     ApplicationArea = Basic, Suite;
-    Caption = 'Schedule Execution WRP Tables';
+    Caption = 'Schedule Export to Azure Data Lake';
     ProcessingOnly = true;
 
 
@@ -9,7 +9,7 @@ report 82561 "ADLSE Schedule Task Assignment"
     {
         dataitem(ADLSETable; "ADLSE Table")
         {
-            RequestFilterFields = "Table ID", ExportCategory, Enabled;
+            RequestFilterFields = ExportCategory;
             trigger OnPreDataItem()
             var
                 ADLSEExecution: Codeunit "ADLSE Execution";
@@ -32,13 +32,13 @@ report 82561 "ADLSE Schedule Task Assignment"
                     {
                         ApplicationArea = All;
                         Caption = 'Description';
-                        ToolTip = 'The description that is displayed in the job queue.';
+                        ToolTip = 'Specifies the description that is displayed in the job queue.';
                     }
                     field(EarliestStartDateTimeControl; EarliestStartDateTime)
                     {
                         ApplicationArea = All;
                         Caption = 'Earliest Start Dqate / Time ';
-                        ToolTip = 'The date and time when the job queue must be executed for the first time.';
+                        ToolTip = 'Specifies the date and time when the job queue must be executed for the first time.';
                     }
                     field(NoofMinutesBetweeenRuns; NoofMinutesBetweenRuns)
                     {
@@ -59,47 +59,47 @@ report 82561 "ADLSE Schedule Task Assignment"
                             field(RunOnMondaysControl; RunOnMondays)
                             {
                                 ApplicationArea = All;
-                                Caption = 'RunOnMondays';
+                                Caption = 'Run On Mondays';
                                 ToolTip = 'Specifies that the job queue entry runs on Mondays.';
                             }
                             field(RunOnTeusdaysControl; RunOnTeusdays)
                             {
                                 ApplicationArea = All;
-                                Caption = 'RunOnTeusdays';
+                                Caption = 'Run On Tuesdays';
                                 ToolTip = 'Specifies that the job queue entry runs on Teusdays.';
                             }
-                            field(RunOnWednesdayControl; RunOnWednesday)
+                            field(RunOnWednesdayControl; RunOnWednesdays)
                             {
                                 ApplicationArea = All;
-                                Caption = 'RunOnWednesday';
+                                Caption = 'Run On Wednesdays';
                                 ToolTip = 'Specifies that the job queue entry runs on Wednesdays.';
                             }
-                            field(RunOnThursdayControl; RunOnThursday)
+                            field(RunOnThursdayControl; RunOnThursdays)
                             {
                                 ApplicationArea = All;
-                                Caption = 'RunOnThursday';
+                                Caption = 'Run On Thursdays';
                                 ToolTip = 'Specifies that the job queue entry runs on Thursdays.';
                             }
                         }
                         group(Recurrence2)
                         {
                             ShowCaption = false;
-                            field(RunOnFridayControl; RunOnFriday)
+                            field(RunOnFridayControl; RunOnFridays)
                             {
                                 ApplicationArea = All;
-                                Caption = 'RunOnFriday';
+                                Caption = 'Run On Fridays';
                                 ToolTip = 'Specifies that the job queue entry runs on Fridays.';
                             }
-                            field(RunOnSaturdayControl; RunOnSaturday)
+                            field(RunOnSaturdayControl; RunOnSaturdays)
                             {
                                 ApplicationArea = All;
-                                Caption = 'RunOnSaturday';
+                                Caption = 'Run On Saturdays';
                                 ToolTip = 'Specifies that the job queue entry runs on Saturdays.';
                             }
                             field(RunOnSundaysControl; RunOnSundays)
                             {
                                 ApplicationArea = All;
-                                Caption = 'RunOnSundays';
+                                Caption = 'Run On Sundays';
                                 ToolTip = 'Specifies that the job queue entry runs on Sundays.';
                             }
                         }
@@ -107,16 +107,6 @@ report 82561 "ADLSE Schedule Task Assignment"
                 }
             }
         }
-
-        trigger OnQueryClosePage(CloseAction: Action): Boolean
-        begin
-
-        end;
-
-        trigger OnOpenPage()
-        begin
-
-        end;
     }
 
     var
@@ -127,26 +117,10 @@ report 82561 "ADLSE Schedule Task Assignment"
         RunOnSundays: Boolean;
         RunOnMondays: Boolean;
         RunOnTeusdays: Boolean;
-        RunOnWednesday: Boolean;
-        RunOnThursday: Boolean;
-        RunOnFriday: Boolean;
-        RunOnSaturday: Boolean;
-
-
-    trigger OnInitReport()
-    begin
-
-    end;
-
-    trigger OnPreReport()
-    begin
-
-    end;
-
-    trigger OnPostReport()
-    begin
-
-    end;
+        RunOnWednesdays: Boolean;
+        RunOnThursdays: Boolean;
+        RunOnFridays: Boolean;
+        RunOnSaturdays: Boolean;
 
     procedure CreateJobQueueEntry(var JobQueueEntry: Record "Job Queue Entry")
     var
@@ -160,10 +134,10 @@ report 82561 "ADLSE Schedule Task Assignment"
         JobQueueEntry."No. of Minutes between Runs" := NoofMinutesBetweenRuns;
         JobQueueEntry."Run on Mondays" := RunOnMondays;
         JobQueueEntry."Run on Tuesdays" := RunOnTeusdays;
-        JobQueueEntry."Run on Wednesdays" := RunOnWednesday;
-        JobQueueEntry."Run on Thursdays" := RunOnThursday;
-        JobQueueEntry."Run on Fridays" := RunOnFriday;
-        JobQueueEntry."Run on Saturdays" := RunOnSaturday;
+        JobQueueEntry."Run on Wednesdays" := RunOnWednesdays;
+        JobQueueEntry."Run on Thursdays" := RunOnThursdays;
+        JobQueueEntry."Run on Fridays" := RunOnFridays;
+        JobQueueEntry."Run on Saturdays" := RunOnSaturdays;
         JobQueueEntry."Run on Sundays" := RunOnSundays;
         JobQueueEntry."Object Type to Run" := JobQueueEntry."Object Type to Run"::Report;
         JobQueueEntry."Object ID to Run" := Report::"ADLSE Schedule Task Assignment";

--- a/businessCentral/app/src/ScheduleTaskAssignment.Report.al
+++ b/businessCentral/app/src/ScheduleTaskAssignment.Report.al
@@ -1,0 +1,175 @@
+report 82561 "ADLSE Schedule Task Assignment"
+{
+    ApplicationArea = Basic, Suite;
+    Caption = 'Schedule Execution WRP Tables';
+    ProcessingOnly = true;
+
+
+    dataset
+    {
+        dataitem(ADLSETable; "ADLSE Table")
+        {
+            RequestFilterFields = "Table ID", ExportCategory, Enabled;
+            trigger OnPreDataItem()
+            var
+                ADLSEExecution: Codeunit "ADLSE Execution";
+            begin
+                ADLSEExecution.StartExport(ADLSETable);
+            end;
+        }
+    }
+    requestpage
+    {
+        SaveValues = true;
+        layout
+        {
+            area(Content)
+            {
+                group(Options)
+                {
+                    Caption = 'Options';
+                    field(JobQueueDescription; Description)
+                    {
+                        ApplicationArea = All;
+                        Caption = 'Description';
+                        ToolTip = 'The description that is displayed in the job queue.';
+                    }
+                    field(EarliestStartDateTimeControl; EarliestStartDateTime)
+                    {
+                        ApplicationArea = All;
+                        Caption = 'Earliest Start Dqate / Time ';
+                        ToolTip = 'The date and time when the job queue must be executed for the first time.';
+                    }
+                    field(NoofMinutesBetweeenRuns; NoofMinutesBetweenRuns)
+                    {
+                        ApplicationArea = All;
+                        Caption = 'No of minutes between runs';
+                        ToolTip = 'Specifies the minimum number of minutes that are to elapse between runs of a job queue entry. The value cannot be less than one minute.';
+                    }
+                }
+
+                group(Recurrence)
+                {
+                    grid(Daysgrid)
+                    {
+                        Caption = 'Recurrence';
+                        group(Recurrence1)
+                        {
+                            ShowCaption = false;
+                            field(RunOnMondaysControl; RunOnMondays)
+                            {
+                                ApplicationArea = All;
+                                Caption = 'RunOnMondays';
+                                ToolTip = 'Specifies that the job queue entry runs on Mondays.';
+                            }
+                            field(RunOnTeusdaysControl; RunOnTeusdays)
+                            {
+                                ApplicationArea = All;
+                                Caption = 'RunOnTeusdays';
+                                ToolTip = 'Specifies that the job queue entry runs on Teusdays.';
+                            }
+                            field(RunOnWednesdayControl; RunOnWednesday)
+                            {
+                                ApplicationArea = All;
+                                Caption = 'RunOnWednesday';
+                                ToolTip = 'Specifies that the job queue entry runs on Wednesdays.';
+                            }
+                            field(RunOnThursdayControl; RunOnThursday)
+                            {
+                                ApplicationArea = All;
+                                Caption = 'RunOnThursday';
+                                ToolTip = 'Specifies that the job queue entry runs on Thursdays.';
+                            }
+                        }
+                        group(Recurrence2)
+                        {
+                            ShowCaption = false;
+                            field(RunOnFridayControl; RunOnFriday)
+                            {
+                                ApplicationArea = All;
+                                Caption = 'RunOnFriday';
+                                ToolTip = 'Specifies that the job queue entry runs on Fridays.';
+                            }
+                            field(RunOnSaturdayControl; RunOnSaturday)
+                            {
+                                ApplicationArea = All;
+                                Caption = 'RunOnSaturday';
+                                ToolTip = 'Specifies that the job queue entry runs on Saturdays.';
+                            }
+                            field(RunOnSundaysControl; RunOnSundays)
+                            {
+                                ApplicationArea = All;
+                                Caption = 'RunOnSundays';
+                                ToolTip = 'Specifies that the job queue entry runs on Sundays.';
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        trigger OnQueryClosePage(CloseAction: Action): Boolean
+        begin
+
+        end;
+
+        trigger OnOpenPage()
+        begin
+
+        end;
+    }
+
+    var
+        Description: Text[30];
+        JobCategoryCodeTxt: Label 'ADLSE', Locked = true;
+        EarliestStartDateTime: DateTime;
+        NoofMinutesBetweenRuns: Integer;
+        RunOnSundays: Boolean;
+        RunOnMondays: Boolean;
+        RunOnTeusdays: Boolean;
+        RunOnWednesday: Boolean;
+        RunOnThursday: Boolean;
+        RunOnFriday: Boolean;
+        RunOnSaturday: Boolean;
+
+
+    trigger OnInitReport()
+    begin
+
+    end;
+
+    trigger OnPreReport()
+    begin
+
+    end;
+
+    trigger OnPostReport()
+    begin
+
+    end;
+
+    procedure CreateJobQueueEntry(var JobQueueEntry: Record "Job Queue Entry")
+    var
+        JobQueueCategory: Record "Job Queue Category";
+    begin
+        Clear(JobQueueEntry);
+        JobQueueCategory.InsertRec(JobCategoryCodeTxt, Description);
+        JobQueueEntry.Init();
+        JobQueueEntry.Status := JobQueueEntry.Status::"On Hold";
+        JobQueueEntry.Description := Description;
+        JobQueueEntry."No. of Minutes between Runs" := NoofMinutesBetweenRuns;
+        JobQueueEntry."Run on Mondays" := RunOnMondays;
+        JobQueueEntry."Run on Tuesdays" := RunOnTeusdays;
+        JobQueueEntry."Run on Wednesdays" := RunOnWednesday;
+        JobQueueEntry."Run on Thursdays" := RunOnThursday;
+        JobQueueEntry."Run on Fridays" := RunOnFriday;
+        JobQueueEntry."Run on Saturdays" := RunOnSaturday;
+        JobQueueEntry."Run on Sundays" := RunOnSundays;
+        JobQueueEntry."Object Type to Run" := JobQueueEntry."Object Type to Run"::Report;
+        JobQueueEntry."Object ID to Run" := Report::"ADLSE Schedule Task Assignment";
+        JobQueueEntry."Earliest Start Date/Time" := EarliestStartDateTime;
+        JobQueueEntry."Report Output Type" := JobQueueEntry."Report Output Type"::"None (Processing only)";
+        JobQueueEntry.Insert(true);
+    end;
+}
+

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -216,23 +216,23 @@ page 82560 "ADLSE Setup"
                 trigger OnAction()
                 var
                     JobQueueEntry: Record "Job Queue Entry";
-                    MAWBScheduleExecutionTables: Report "ADLSE Schedule Task Assignment";
+                    ADLSEScheduleTaskAssignment: Report "ADLSE Schedule Task Assignment";
                     SavedData: Text;
                     xmldata: Text;
                 begin
                     JobQueueEntry.SetFilter("User ID", UserId());
                     JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Report);
-                    JobQueueEntry.SetRange("Object ID to Run", 11332001);
+                    JobQueueEntry.SetRange("Object ID to Run",  Report::"ADLSE Schedule Task Assignment");
                     JobQueueEntry.SetCurrentKey(SystemCreatedAt);
                     JobQueueEntry.SetAscending(SystemCreatedAt, false);
 
                     if JobQueueEntry.FindFirst() then
                         SavedData := JobQueueEntry.GetReportParameters();
 
-                    xmldata := MAWBScheduleExecutionTables.RunRequestPage(SavedData);
+                    xmldata := ADLSEScheduleTaskAssignment.RunRequestPage(SavedData);
 
                     if xmldata <> '' then begin
-                        MAWBScheduleExecutionTables.CreateJobQueueEntry(JobQueueEntry);
+                        ADLSEScheduleTaskAssignment.CreateJobQueueEntry(JobQueueEntry);
                         JobQueueEntry.SetReportParameters(xmldata);
                         JobQueueEntry.Modify();
                     end;

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -308,7 +308,7 @@ page 82560 "ADLSE Setup"
             {
                 Caption = 'Job Queue';
                 ApplicationArea = All;
-                ToolTip = 'Show the scheduled Job Queues for the export to Datalake';
+                ToolTip = 'Specifies the scheduled Job Queues for the export to Datalake.';
                 Image = BulletList;
                 trigger OnAction()
                 var
@@ -317,6 +317,14 @@ page 82560 "ADLSE Setup"
                     JobQueueEntry.SetFilter("Object ID to Run", '%1|%2', Codeunit::"ADLSE Execution", Report::"ADLSE Schedule Task Assignment");
                     Page.Run(Page::"Job Queue Entries", JobQueueEntry);
                 end;
+            }
+            action("Export Category")
+            {
+                Caption = 'Export Category';
+                ApplicationArea = All;
+                ToolTip = 'Specifies the Export Categories available for scheduling the export to Datalake.';
+                Image = Export;
+                RunObject = page "ADLSE Export Categories";
             }
         }
         area(Promoted)

--- a/businessCentral/app/src/SetupTables.Page.al
+++ b/businessCentral/app/src/SetupTables.Page.al
@@ -84,6 +84,12 @@ page 82561 "ADLSE Setup Tables"
                     Caption = 'Last timestamp deleted';
                     Visible = false;
                 }
+                field(ExportCategory; Rec.ExportCategory)
+                {
+                    Caption = 'Export Category';
+                    ApplicationArea = All;
+                    ToolTip = 'Export Category which can be linked to tables which are part of the export to Azure Datalake. The Category can be used to schedule the export.';
+                }
             }
         }
     }
@@ -201,6 +207,25 @@ page 82561 "ADLSE Setup Tables"
                     ADLSETable.Reset();
                     XmlPort.Run(XmlPort::"BC2ADLS Export", false, false, ADLSETable);
                     CurrPage.Update(false);
+                end;
+            }
+            action(AssignExportCategory)
+            {
+                ApplicationArea = All;
+                Caption = 'Assign Export Category';
+                Image = Apply;
+                ToolTip = 'Assign an Export Category to the Table.';
+
+                trigger OnAction()
+                var
+                    ADLSETable: Record "ADLSE Table";
+                    AssignExportCategory: Page "ADLSE Assign Export Category";
+                begin
+                    CurrPage.SetSelectionFilter(ADLSETable);
+                    AssignExportCategory.LookupMode(true);
+                    if AssignExportCategory.RunModal() = Action::LookupOK then
+                        ADLSETable.ModifyAll(ExportCategory, AssignExportCategory.GetExportCategoryCode());
+                    CurrPage.Update();
                 end;
             }
         }

--- a/businessCentral/app/src/SetupTables.Page.al
+++ b/businessCentral/app/src/SetupTables.Page.al
@@ -88,7 +88,6 @@ page 82561 "ADLSE Setup Tables"
                 {
                     Caption = 'Export Category';
                     ApplicationArea = All;
-                    ToolTip = 'Export Category which can be linked to tables which are part of the export to Azure Datalake. The Category can be used to schedule the export.';
                 }
             }
         }

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -60,6 +60,7 @@ table 82561 "ADLSE Table"
         {
             TableRelation = "ADLSE Export Category";
             DataClassification = CustomerContent;
+            ToolTip = 'Specifies the Export Category which can be linked to tables which are part of the export to Azure Datalake. The Category can be used to schedule the export.';
         }
     }
 

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -106,9 +106,10 @@ table 82561 "ADLSE Table"
     var
         ADLSESetup: Record "ADLSE Setup";
     begin
-        ADLSESetup.SchemaExported();
-
-        CheckNotExporting();
+        if (Rec."Table ID" <> xRec."Table ID") or (Rec.Enabled <> xRec.Enabled) then begin
+            ADLSESetup.SchemaExported();
+            CheckNotExporting();
+        end;
     end;
 
     var

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -56,6 +56,11 @@ table 82561 "ADLSE Table"
             ObsoleteTag = '1.2.2.0';
             ObsoleteState = Removed;
         }
+        field(10; ExportCategory; Code[50])
+        {
+            TableRelation = "ADLSE Export Category";
+            DataClassification = CustomerContent;
+        }
     }
 
     keys


### PR DESCRIPTION
One of our customer would like to be able to export some tables every hours, while exporting other tables only once a day. In order to accommodate this, we have extended the functionality with a possibility to have different job queue for the export.
