### PR TITLE
Implement bulk reset functionality

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,13 @@
+feat(bulk-reset): Implement bulk table reset functionality
+
+- Add ResetTables procedure to ADLSE Table for bulk reset operations
+- Implement OnAfterResetSelectedBulk event in External Events
+- Maintain backward compatibility with existing reset functionality
+- Update documentation with implementation details and tasks
+
+Changes:
+- Added ResetTables procedure in ADLSE Table with proper documentation
+- Added OnAfterResetSelectedBulk event with both internal and external implementations
+- Updated reset-table-functionality.md with implementation details
+
+Related: #issue_number

--- a/businessCentral/app/src/ExternalEvents.Codeunit.al
+++ b/businessCentral/app/src/ExternalEvents.Codeunit.al
@@ -152,6 +152,11 @@ codeunit 82574 "ADLSE External Events"
         MyBusinessOnRefreshOptions(ADLSESetup.SystemId, ADLSESetup."Storage Type", Url, WebClientUrl);
     end;
 
+    internal procedure OnAfterResetSelectedBulk(TableList: List of [Guid]; TableIdList: List of [Integer])
+    begin
+        MyBusinessEventOnAfterResetSelectedBulk(TableList, TableIdList);
+    end;
+
     local procedure GetSetup()
     var
         ADLSESetup: Record "ADLSE Setup";
@@ -235,6 +240,11 @@ codeunit 82574 "ADLSE External Events"
 
     [ExternalBusinessEvent('OnRefreshOptions', 'Refresh Options', 'When the options are refreshed', EventCategory::ADLSE)]
     local procedure MyBusinessOnRefreshOptions(SystemId: Guid; "Storage Type": Enum "ADLSE Storage Type"; Url: Text[250]; WebClientUrl: Text[250])
+    begin
+    end;
+
+    [ExternalBusinessEvent('OnAfterResetSelectedBulk', 'Multiple tables reset completed', EventCategory::ADLSE)]
+    local procedure MyBusinessEventOnAfterResetSelectedBulk(SystemIds: List of [Guid]; TableIds: List of [Integer])
     begin
     end;
 

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -293,6 +293,32 @@ table 82561 "ADLSE Table"
                 end;
             until Field.Next() = 0;
     end;
+
+    /// <summary>
+    /// Resets multiple tables in bulk, maintaining individual reset behavior while providing a bulk operation event.
+    /// </summary>
+    /// <param name="SelectedADLSETables">The record variable containing the selected tables to reset.</param>
+    /// <error>No tables were selected for reset.</error>
+    [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'rm')]
+    procedure ResetTables(var SelectedADLSETables: Record "ADLSE Table")
+    var
+        TableList: List of [Guid];
+        TableIdList: List of [Integer];
+        ADLSEExternalEvents: Codeunit "ADLSE External Events";
+        NoTablesSelectedErr: Label 'No tables were selected for reset.';
+    begin
+        if not SelectedADLSETables.FindSet() then
+            Error(NoTablesSelectedErr);
+
+        repeat
+            TableList.Add(SelectedADLSETables.SystemId);
+            TableIdList.Add(SelectedADLSETables."Table ID");
+            SelectedADLSETables.ResetSelected();
+        until SelectedADLSETables.Next() = 0;
+        
+        ADLSEExternalEvents.OnAfterResetSelectedBulk(TableList, TableIdList);
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnAfterResetSelected(ADLSETable: Record "ADLSE Table")
     begin


### PR DESCRIPTION
Add ResetTables procedure to ADLSE Table for bulk reset operations
Implement OnAfterResetSelectedBulk event in External Events
Maintain backward compatibility with existing reset functionality

Changes:
- Added ResetTables procedure in ADLSE Table with proper documentation
- Added OnAfterResetSelectedBulk event with both internal and external implementations

