### PR TITLE
fix for tracking deleted records with changecompany

### DIFF
--- a/businessCentral/app/src/DeletedRecord.Table.al
+++ b/businessCentral/app/src/DeletedRecord.Table.al
@@ -53,7 +53,7 @@ table 82563 "ADLSE Deleted Record"
             exit;
 
         if RecordRef.CurrentCompany() <> CompanyName() then //workarround for records which are deleted usings changecompany
-            This.ChangeCompany(RecordRef.CurrentCompany());
+            this.ChangeCompany(RecordRef.CurrentCompany());
 
         SystemIdFieldRef := RecordRef.Field(RecordRef.SystemIdNo());
         if IsNullGuid(SystemIdFieldRef.Value()) then

--- a/businessCentral/app/src/DeletedRecord.Table.al
+++ b/businessCentral/app/src/DeletedRecord.Table.al
@@ -52,6 +52,9 @@ table 82563 "ADLSE Deleted Record"
         if RecordRef.IsTemporary() then
             exit;
 
+        if RecordRef.CurrentCompany() <> CompanyName() then //workarround for records which are deleted usings changecompany
+            ChangeCompany(RecordRef.CurrentCompany());
+
         SystemIdFieldRef := RecordRef.Field(RecordRef.SystemIdNo());
         if IsNullGuid(SystemIdFieldRef.Value()) then
             exit;

--- a/businessCentral/app/src/DeletedRecord.Table.al
+++ b/businessCentral/app/src/DeletedRecord.Table.al
@@ -53,7 +53,7 @@ table 82563 "ADLSE Deleted Record"
             exit;
 
         if RecordRef.CurrentCompany() <> CompanyName() then //workarround for records which are deleted usings changecompany
-            ChangeCompany(RecordRef.CurrentCompany());
+            This.ChangeCompany(RecordRef.CurrentCompany());
 
         SystemIdFieldRef := RecordRef.Field(RecordRef.SystemIdNo());
         if IsNullGuid(SystemIdFieldRef.Value()) then

--- a/businessCentral/app/src/Execution.Codeunit.al
+++ b/businessCentral/app/src/Execution.Codeunit.al
@@ -214,6 +214,9 @@ codeunit 82569 "ADLSE Execution"
         if RecRef.Number = Database::"ADLSE Deleted Record" then
             exit;
 
+        if RecRef.CurrentCompany() <> CompanyName() then //workarround for records which are deleted usings changecompany
+            ADLSETableLastTimestamp.ChangeCompany(RecRef.CurrentCompany());
+
         if DeletedTablesNottoSync.Get(RecRef.Number) then
             exit;
 


### PR DESCRIPTION
Issue solved for tracking deletions with change company. Scenario: in company A record in company B is deleted using record.changecompany. The global delete trigger fires in company A which has no record using that systemid causing the deleted record not to be stored in the deleted records table in company B. In direct consequence the deleted record is not communicated to fabric/datalake.