### PR TITLE
ReadCommitted on export

### DIFF
--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -187,8 +187,7 @@ codeunit 82561 "ADLSE Execute"
         if not RecordRef.ReadPermission() then
             Error(InsufficientReadPermErr);
 
-        if (ADLSESetup."Read Committed") then
-            RecordRef.ReadIsolation := RecordRef.ReadIsolation::ReadCommitted;
+        RecordRef.ReadIsolation := RecordRef.ReadIsolation::ReadCommitted;
         if ADLSESeekData.FindRecords(RecordRef) then begin
             if EmitTelemetry then begin
                 TableCaption := RecordRef.Caption();
@@ -274,9 +273,7 @@ codeunit 82561 "ADLSE Execute"
         CurrentDateTime := CurrentDateTime();
         SetFilterForDeletes(TableID, DeletedLastEntryNo, ADLSEDeletedRecord);
 
-
-        if (ADLSESetup."Read Committed") then
-            ADLSEDeletedRecord.ReadIsolation := ADLSEDeletedRecord.ReadIsolation::ReadCommitted;
+        ADLSEDeletedRecord.ReadIsolation := ADLSEDeletedRecord.ReadIsolation::ReadCommitted;
         if ADLSESeekData.FindRecords(ADLSEDeletedRecord) then begin
             RecordRef.Open(ADLSEDeletedRecord."Table ID");
 

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -99,6 +99,10 @@ page 82560 "ADLSE Setup"
                         Enabled = not ExportInProgress;
 
                     }
+                    field("Read Committed"; Rec."Read Committed")
+                    {
+                        Enabled = not ExportInProgress;
+                    }
 
                     field("Emit telemetry"; Rec."Emit telemetry") { }
                     field("Translations"; Rec.Translations)

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -111,11 +111,6 @@ page 82560 "ADLSE Setup"
                         Enabled = not ExportInProgress;
 
                     }
-                    field("Read Committed"; Rec."Read Committed")
-                    {
-                        Enabled = not ExportInProgress;
-                    }
-
                     field("Emit telemetry"; Rec."Emit telemetry") { }
                     field("Translations"; Rec.Translations)
                     {

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -207,6 +207,12 @@ table 82560 "ADLSE Setup"
             ToolTip = 'Specifies the delayed export time in seconds (0 = No delay).';
             InitValue = 0;
         }
+        field(75; "Read Committed"; Boolean)
+        {
+            Caption = 'Use Read Committed';
+            ToolTip = 'When selecting records for export, use Read Committed. Records part of transactions in progress wont be included before fully committed. Only enable this if you have tri-state commit enabled.';
+            InitValue = true;
+        }
 
     }
 

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -220,13 +220,6 @@ table 82560 "ADLSE Setup"
             ToolTip = 'Specifies the delayed export time in seconds (0 = No delay).';
             InitValue = 0;
         }
-        field(75; "Read Committed"; Boolean)
-        {
-            Caption = 'Use Read Committed';
-            ToolTip = 'When selecting records for export, use Read Committed. Records part of transactions in progress wont be included before fully committed. Only enable this if you have tri-state commit enabled.';
-            InitValue = true;
-        }
-
     }
 
     keys


### PR DESCRIPTION
Use ReadCommitted on export of changes and deleted records to avoid exporting a non-completed transaction that could potentially be rolled back. 

Basically this adds : 

        if (ADLSESetup."Read Committed") then
            RecordRef.ReadIsolation := RecordRef.ReadIsolation::ReadCommitted;

Before calling the report to extract changes. This means records that are in  the middle of a transaction will not be picked up. 

Since this only works if your database has Read Committed Snapshot isolation, I added it as an option on adls setup. All Cloud instances should have this, on prem / docker you have to enable it, and you probably should. 