### PR TITLE
Add setup table execute permission to sets

### DIFF
--- a/businessCentral/app/permissions/Api.PermissionSet.al
+++ b/businessCentral/app/permissions/Api.PermissionSet.al
@@ -9,7 +9,8 @@ permissionset 82563 "ADLSE - API"
     Assignable = true;
     Caption = 'ADLS - Api', MaxLength = 30;
 
-    Permissions = tabledata "ADLSE Table" = RMI,
+    Permissions = table "ADLSE Setup" = x,
+                  tabledata "ADLSE Table" = RMI,
                   tabledata "ADLSE Setup" = R,
                   tabledata "ADLSE Current Session" = R,
                   tabledata "ADLSE Run" = R,

--- a/businessCentral/app/permissions/Execute.PermissionSet.al
+++ b/businessCentral/app/permissions/Execute.PermissionSet.al
@@ -9,7 +9,8 @@ permissionset 82561 "ADLSE - Execute"
     Assignable = true;
     Caption = 'ADLS - Execute', MaxLength = 30;
 
-    Permissions = tabledata "ADLSE Setup" = RM,
+    Permissions = table "ADLSE Setup" = x,
+                  tabledata "ADLSE Setup" = RM,
                   tabledata "ADLSE Table" = RM,
                   tabledata "ADLSE Field" = R,
                   tabledata "ADLSE Deleted Record" = R,

--- a/businessCentral/app/permissions/Setup.PermissionSet.al
+++ b/businessCentral/app/permissions/Setup.PermissionSet.al
@@ -12,6 +12,7 @@ permissionset 82560 "ADLSE - Setup"
     Permissions = table "Deleted Tables Not to Sync" = x,
                   table "ADLSE Export Category" = x,
                   table "ADLSE Export Category Table" = x,
+                  table "ADLSE Setup" = x,
                   tabledata "ADLSE Setup" = RIMD,
                   tabledata "ADLSE Table" = RIMD,
                   tabledata "ADLSE Field" = RIMD,


### PR DESCRIPTION
We got this permission missing as we were doing basic api calls.
Permission to these procedure are equal to reading rights in my opinion, so no harm to add them.
Add setup table execute permission to sets