### PR TITLE
Options text size increased

### DIFF
--- a/businessCentral/app/src/SetupTables.Page.al
+++ b/businessCentral/app/src/SetupTables.Page.al
@@ -154,7 +154,7 @@ page 82561 "ADLSE Setup Tables"
                 trigger OnAction()
                 var
                     SelectedADLSETable: Record "ADLSE Table";
-                    Options: Text[30];
+                    Options: Text[50];
                     OptionStringLbl: Label 'Current Company,All Companies';
                     ChosenOption: Integer;
                 begin


### PR DESCRIPTION
"OptionStringLbl" length can be > 30 due to translations changes. If working on BC environment that is in German language it's 32 character long and "Reset" action doesn't work anymore.