### PR TITLE
Handle open mirroring storage type in ResetTableExport procedure

### DIFF
--- a/businessCentral/app/src/Communication.Codeunit.al
+++ b/businessCentral/app/src/Communication.Codeunit.al
@@ -418,6 +418,8 @@ codeunit 82562 "ADLSE Communication"
                 ADLSEGen2Util.CreateOrUpdateJsonBlob(GetBaseUrl() + StrSubstNo(ResetTableExportTxt, ADLSEUtil.GetDataLakeCompliantTableName(ltableId)), ADLSECredentials, '', Body);
             "ADLSE Storage Type"::"Azure Data Lake":
                 ADLSEGen2Util.RemoveDeltasFromDataLake(ADLSEUtil.GetDataLakeCompliantTableName(ltableId), ADLSECredentials, AllCompanies);
+            "ADLSE Storage Type"::"Open Mirroring":
+                ADLSEGen2Util.DropTableFromOpenMirroring(ADLSEUtil.GetDataLakeCompliantTableName(ltableId), ADLSECredentials, AllCompanies);
         end;
     end;
 }

--- a/businessCentral/app/src/Gen2Util.Codeunit.al
+++ b/businessCentral/app/src/Gen2Util.Codeunit.al
@@ -330,6 +330,35 @@ codeunit 82568 "ADLSE Gen 2 Util"
         end;
     end;
 
+    procedure DropTableFromOpenMirroring(ADLSEntityName: Text; ADLSECredentials: Codeunit "ADLSE Credentials"; AllCompanies: Boolean)
+    var
+        ADLSESetup: Record "ADLSE Setup";
+        ADLSEHttp: Codeunit "ADLSE Http";
+        IsHandled: Boolean;
+        Response: Text;
+        Url: Text;
+    begin
+        // DELETE https://onelake.dfs.fabric.microsoft.com/{CONTAINER_ID}/{MIRRORED_DATABASE_ID}/Files/LandingZone/{FOLDER_NAME}?recursive=true
+        // https://learn.microsoft.com/en-us/fabric/database/mirrored-database/open-mirroring-landing-zone-format#drop-table
+        ADLSESetup.GetSingleton();
+
+        OnBeforeDropTableFromOpenMirroring(ADLSEntityName, ADLSECredentials, AllCompanies, IsHandled);
+        if IsHandled then
+            exit;
+
+
+        if AllCompanies then begin
+            Url := ADLSESetup.LandingZone;
+            Url += '/' + ADLSEntityName + '?recursive=true';
+
+            ADLSEHttp.SetMethod("ADLSE Http Method"::Delete);
+            ADLSEHttp.SetUrl(Url);
+            ADLSEHttp.SetAuthorizationCredentials(ADLSECredentials);
+            ADLSEHttp.InvokeRestApi(Response)
+        end;
+    end;
+
+
     [IntegrationEvent(false, false)]
     local procedure OnBeforeGetBlobContent(BlobPath: Text; ADLSECredentials: Codeunit "ADLSE Credentials"; var BlobExists: Boolean; var Content: JsonObject; var IsHandled: Boolean)
     begin
@@ -357,6 +386,11 @@ codeunit 82568 "ADLSE Gen 2 Util"
 
     [Integrationevent(false, false)]
     local procedure OnBeforeRemoveDeltasFromDataLake(ADLSEntityName: Text; ADLSECredentials: Codeunit "ADLSE Credentials"; AllCompanies: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [Integrationevent(false, false)]
+    local procedure OnBeforeDropTableFromOpenMirroring(ADLSEntityName: Text; ADLSECredentials: Codeunit "ADLSE Credentials"; AllCompanies: Boolean; var IsHandled: Boolean)
     begin
     end;
 }

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -140,7 +140,10 @@ page 82560 "ADLSE Setup"
                         end;
                     }
                     field("Export Enum as Integer"; Rec."Export Enum as Integer") { }
-                    field("Delete Table"; Rec."Delete Table") { }
+                    field("Delete Table"; Rec."Delete Table")
+                    {
+                        Editable = not this.FabricOpenMirroring;
+                    }
                     field("Delivered DateTime"; Rec."Delivered DateTime") { }
                     field("Export Company Database Tables"; Rec."Export Company Database Tables")
                     {

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -118,8 +118,10 @@ table 82560 "ADLSE Setup"
             var
                 OpenMirroringPreviewLbl: label 'Microsoft Fabric - Open Mirroring connection in bc2adls is still in preview. Please use it with caution.';
             begin
-                if Rec."Storage Type" = Rec."Storage Type"::"Open Mirroring" then
+                if Rec."Storage Type" = Rec."Storage Type"::"Open Mirroring" then begin
+                    Rec."Delete Table" := true;
                     Message(OpenMirroringPreviewLbl);
+                end;
             end;
         }
 

--- a/businessCentral/app/src/SetupTables.Page.al
+++ b/businessCentral/app/src/SetupTables.Page.al
@@ -154,12 +154,20 @@ page 82561 "ADLSE Setup Tables"
                 trigger OnAction()
                 var
                     SelectedADLSETable: Record "ADLSE Table";
+                    ADLSESetup: Record "ADLSE Setup";
                     Options: Text[50];
                     OptionStringLbl: Label 'Current Company,All Companies';
                     ChosenOption: Integer;
                 begin
                     Options := OptionStringLbl;
-                    ChosenOption := Dialog.StrMenu(Options, 1, 'Do you want to reset the selected tables for the current company or all companies?');
+                    ADLSESetup.GetSingleton();
+                    if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then begin
+                        if Confirm('Do you want to reset the selected tables for all companies?', true) then
+                            ChosenOption := 2
+                        else
+                            exit;
+                    end else
+                        ChosenOption := Dialog.StrMenu(Options, 1, 'Do you want to reset the selected tables for the current company or all companies?');
                     CurrPage.SetSelectionFilter(SelectedADLSETable);
                     case ChosenOption of
                         0:

--- a/businessCentral/app/src/SetupTables.Page.al
+++ b/businessCentral/app/src/SetupTables.Page.al
@@ -157,17 +157,19 @@ page 82561 "ADLSE Setup Tables"
                     ADLSESetup: Record "ADLSE Setup";
                     Options: Text[50];
                     OptionStringLbl: Label 'Current Company,All Companies';
+                    ResetTablesForAllCompaniesQst: Label 'Do you want to reset the selected tables for all companies?';
+                    ResetTablesQst: Label 'Do you want to reset the selected tables for the current company or all companies?';
                     ChosenOption: Integer;
                 begin
                     Options := OptionStringLbl;
                     ADLSESetup.GetSingleton();
                     if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then begin
-                        if Confirm('Do you want to reset the selected tables for all companies?', true) then
+                        if Confirm(ResetTablesForAllCompaniesQst, true) then
                             ChosenOption := 2
                         else
                             exit;
                     end else
-                        ChosenOption := Dialog.StrMenu(Options, 1, 'Do you want to reset the selected tables for the current company or all companies?');
+                        ChosenOption := Dialog.StrMenu(Options, 1, ResetTablesQst);
                     CurrPage.SetSelectionFilter(SelectedADLSETable);
                     case ChosenOption of
                         0:


### PR DESCRIPTION
Implement functionality to drop tables in open mirroring storage type, defaulting to all companies for resets. Adjust the "Delete Table" option in ADLSE Setup to be non-editable when using open mirroring. Ensure user confirmation for resetting tables reflects this change.

Fixes #282