### PR TITLE
Enhance BC2ADLS Naming Conventions for Improved Readability

### DIFF
--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -69,7 +69,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
         foreach FieldId in FieldIdList do begin
             FieldRef := RecordRef.Field(FieldId);
             Clear(Column);
-            Column.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
+            Column.Add('Name', ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
             if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then
                 Column.Add('DataType', GetOpenMirrorDataFormat(FieldRef.Type))
             else

--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -59,17 +59,17 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
 
         FieldRef := RecordRef.Field(2000000000);
         if ADLSEUtil.IsTablePerCompany(TableID) then begin
-            Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef.Name, FieldRef.Number));
+            Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
             Imports.Add(this.GetCompanyFieldName());
         end else
-            Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef.Name, FieldRef.Number));
+            Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
         Content.Add('keyColumns', Imports);
 
         ADLSESetup.GetSingleton();
         foreach FieldId in FieldIdList do begin
             FieldRef := RecordRef.Field(FieldId);
             Clear(Column);
-            Column.Add('Name', ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef.Name, FieldRef.Number));
+            Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
             if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then
                 Column.Add('DataType', GetOpenMirrorDataFormat(FieldRef.Type))
             else
@@ -176,7 +176,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
                 FieldLength := 15; // 15 is the default max number of digits. FieldRef.Length is giving the wrong number back for decimal
             Result.Add(
                 CreateAttributeJson(
-                    ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef.Name, FieldRef.Number),
+                    ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef),
                     DataFormat,
                     FieldRef.Name,
                     AppliedTraits,

--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -69,7 +69,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
         foreach FieldId in FieldIdList do begin
             FieldRef := RecordRef.Field(FieldId);
             Clear(Column);
-            Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
+            Column.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
             if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then
                 Column.Add('DataType', GetOpenMirrorDataFormat(FieldRef.Type))
             else

--- a/businessCentral/app/src/EnumTranslation.Table.al
+++ b/businessCentral/app/src/EnumTranslation.Table.al
@@ -53,7 +53,7 @@ table 82567 "ADLSE Enum Translation"
         Rec."Table Id" := TableId;
         Rec."Compliant Table Name" := CopyStr(ADLSEUtil.GetDataLakeCompliantTableName(TableId), 1, MaxStrLen((Rec."Compliant Table Name")));
         Rec."Field Id" := FieldNo;
-        Rec."Compliant Field Name" := CopyStr(ADLSEUtil.GetDataLakeCompliantFieldName(FieldName, FieldNo), 1, MaxStrLen((Rec."Compliant Field Name")));
+        Rec."Compliant Field Name" := CopyStr(ADLSEUtil.GetDataLakeCompliantFieldName(TableId, FieldNo), 1, MaxStrLen((Rec."Compliant Field Name")));
         Rec.Insert(true);
     end;
 

--- a/businessCentral/app/src/EnumTranslationLang.Table.al
+++ b/businessCentral/app/src/EnumTranslationLang.Table.al
@@ -72,7 +72,7 @@ table 82568 "ADLSE Enum Translation Lang"
         Rec."Table Id" := TableId;
         Rec."Compliant Table Name" := CopyStr(ADLSEUtil.GetDataLakeCompliantTableName(TableId), 1, MaxStrLen((Rec."Compliant Table Name")));
         Rec."Field Id" := FieldNo;
-        Rec."Compliant Field Name" := CopyStr(ADLSEUtil.GetDataLakeCompliantFieldName(FieldName, FieldNo), 1, MaxStrLen((Rec."Compliant Field Name")));
+        Rec."Compliant Field Name" := CopyStr(ADLSEUtil.GetDataLakeCompliantFieldName(TableId, FieldNo), 1, MaxStrLen((Rec."Compliant Field Name")));
         Rec."Enum Value Id" := EnumValueOrdinal;
         Rec."Enum Value Caption" := CopyStr(EnumValueName, 1, MaxStrLen(Rec."Enum Value Caption"));
         Rec.Insert(true);

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -140,6 +140,12 @@ page 82560 "ADLSE Setup"
                         end;
                     }
                     field("Export Enum as Integer"; Rec."Export Enum as Integer") { }
+                    field("Use Field Captions"; Rec."Use Field Captions")
+                    {
+                    }
+                    field("Use IDs for Duplicates Only"; Rec."Use IDs for Duplicates Only")
+                    {
+                    }
                     field("Delete Table"; Rec."Delete Table")
                     {
                         Editable = not this.FabricOpenMirroring;

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -222,6 +222,18 @@ table 82560 "ADLSE Setup"
             ToolTip = 'Specifies the delayed export time in seconds (0 = No delay).';
             InitValue = 0;
         }
+        field(75; "Use Field Captions"; Boolean)
+        {
+            Caption = 'Use Captions';
+            ToolTip = 'Specifies if the captions of fields will be used instead of names.';
+            InitValue = false;
+        }
+        field(80; "Use IDs for Duplicates Only"; Boolean)
+        {
+            Caption = 'IDs for Duplicates Only';
+            ToolTip = 'Specifies that table and field IDs will only be used in names if duplicates exist.';
+            InitValue = false;
+        }
     }
 
     keys

--- a/businessCentral/app/src/SetupFields.Page.al
+++ b/businessCentral/app/src/SetupFields.Page.al
@@ -17,10 +17,10 @@ page 82562 "ADLSE Setup Fields"
         {
             repeater(GroupName)
             {
-                field("FieldCaption"; Rec.FieldCaption) 
-		{ 
+                field("FieldCaption"; Rec.FieldCaption)
+                {
                     StyleExpr = StyleExprAsText;
-		}
+                }
 
                 field("Field ID"; Rec."Field ID")
                 {
@@ -29,10 +29,10 @@ page 82562 "ADLSE Setup Fields"
                     Visible = false;
                 }
 
-                field(Enabled; Rec.Enabled) 
-		{ 
+                field(Enabled; Rec.Enabled)
+                {
                     StyleExpr = StyleExprAsText;
-		}
+                }
                 field(IsPartOfPrimaryKey; IsPartOfPrimaryKey)
                 {
                     ApplicationArea = All;
@@ -117,7 +117,7 @@ page 82562 "ADLSE Setup Fields"
         ADLSEUtil: Codeunit "ADLSE Util";
     begin
         Field.Get(Rec."Table ID", Rec."Field ID");
-        ADLSFieldName := ADLSEUtil.GetDataLakeCompliantFieldName(Field.FieldName, Field."No.");
+        ADLSFieldName := ADLSEUtil.GetDataLakeCompliantFieldName(Field.TableNo, Field."No.");
         FieldClassName := Field.Class;
         FieldTypeName := Field."Type Name";
         FieldObsoleteState := Field.ObsoleteState;


### PR DESCRIPTION
Introduce options to use field captions instead of names and to append IDs only for duplicate table and field names in the BC2ADLS export process. This change aims to simplify the naming conventions, reduce complexity in semantic model development, and enhance downstream data consumption. Resolves #286