### PR TITLE
Fix filter name in GetDataLakeCompliantTableName procedure for consistency

### DIFF
--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -150,7 +150,7 @@ codeunit 82564 "ADLSE Util"
         if ADLSESetup."Use IDs for Duplicates Only" then begin
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
             AllObjWithCaption.SetFilter("Object ID", '<>%1', TableID);
-            AllObjWithCaption.SetFilter("Object Caption", OrigTableName);
+            AllObjWithCaption.SetFilter("Object Name", OrigTableName);
             if AllObjWithCaption.IsEmpty() then // there is not a duplicate table caption
                 exit(GetDataLakeCompliantName(OrigTableName))
             else


### PR DESCRIPTION
Update the filter name in the GetDataLakeCompliantTableName procedure to ensure consistency in referencing object names. This change addresses a recently introduced bug related to using IDs in table names when duplicates are present.

Fixes #294