### PR TITLE
Exclude removed fields in InsertForTable procedure

### DIFF
--- a/businessCentral/app/src/Field.Table.al
+++ b/businessCentral/app/src/Field.Table.al
@@ -105,6 +105,7 @@ table 82562 "ADLSE Field"
     begin
         Field.SetRange(TableNo, ADLSETable."Table ID");
         Field.SetFilter("No.", '<%1', 2000000000); // no system fields
+        Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
 
         if Field.FindSet() then
             repeat


### PR DESCRIPTION
A filter has been added to the InsertForTable procedure to exclude obsolete fields marked as removed, preventing errors when opening the choose fields page in setup.

Fixes #298