### PR TITLE
Prevent removal of '%' character from column names. Fixes #302

### DIFF
--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -221,7 +221,7 @@ codeunit 82564 "ADLSE Util"
             if StrPos(AlphabetsLowerTxt, Letter) = 0 then
                 if StrPos(AlphabetsUpperTxt, Letter) = 0 then
                     if StrPos(NumeralsTxt, Letter) = 0 then
-                        if ADLSESetup."Use Field Captions" then begin
+                        if ADLSESetup."Use IDs for Duplicates Only" then begin
                             if StrPos(SpecialCharsTxt, Letter) = 0 then
                                 AddToResult := false;
                         end


### PR DESCRIPTION
The changes ensure that the '%' character is retained in CSV column headers and _metadata.json schema definitions, addressing issues with duplicate column names in the BC2ADLS app. This fix allows for proper differentiation between columns like EmployeeOwnership and EmployeeOwnership%, which previously resulted in conflicts due to the removal of special characters.

Fixes #302