### PR TITLE
Make string columns nullable for Fabric Open mirroring

### DIFF
--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -72,7 +72,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
             Column.Add('Name', ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
             if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then begin
                 Column.Add('DataType', GetOpenMirrorDataFormat(FieldRef.Type));
-                if (FieldRef.Number <> RecordRef.SystemIdNo()) and (GetOpenMirrorDataFormat(FieldRef.Type) <> GetCDMDataFormat_String()) then
+                if (FieldRef.Number <> RecordRef.SystemIdNo()) then
                     Column.Add('IsNullable', true);
             end else
                 Column.Add('DataType', GetFabricDataFormat(FieldRef.Type));


### PR DESCRIPTION
Update the logic to ensure that all string column types in the _metadata.json file are set to "IsNullable": true, except for key columns. This change addresses issues encountered when loading data with null values from BC, specifically for "Delete" type rows.

Fixes #310