### PR TITLE
Add option to use table captions in BC export app

### DIFF
--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
 
     procedure CreateEntityContent(TableID: Integer; FieldIdList: List of [Integer]) Content: JsonObject
     var
+        ADLSESetup: Record "ADLSE Setup";
         ADLSEUtil: Codeunit "ADLSE Util";
         Definition: JsonObject;
         Definitions: JsonArray;
@@ -25,6 +26,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
         Imports: JsonArray;
         EntityName: Text;
     begin
+        ADLSESetup.GetSingleton();
         Content.Add('jsonSchemaSemanticVersion', '1.0.0');
         Import.Add('corpusPath', 'cdm:/foundations.cdm.json');
         Imports.Add(Import);
@@ -32,7 +34,10 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
         EntityName := ADLSEUtil.GetDataLakeCompliantTableName(TableID);
         Definition.Add('entityName', EntityName);
         Definition.Add('exhibitsTraits', BlankArray);
-        Definition.Add('displayName', ADLSEUtil.GetTableName(TableID));
+        if ADLSESetup."Use Table Captions" then
+            Definition.Add('displayName', ADLSEUtil.GetTableCaption(TableID))
+        else
+            Definition.Add('displayName', ADLSEUtil.GetTableName(TableID));
         Definition.Add('description', StrSubstNo(RepresentsTableTxt, ADLSEUtil.GetTableName(TableID)));
         Definition.Add('hasAttributes', CreateAttributes(TableID, FieldIdList));
         Definitions.Add(Definition);

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -143,6 +143,9 @@ page 82560 "ADLSE Setup"
                     field("Use Field Captions"; Rec."Use Field Captions")
                     {
                     }
+                    field("Use Table Captions"; Rec."Use Table Captions")
+                    {
+                    }
                     field("Use IDs for Duplicates Only"; Rec."Use IDs for Duplicates Only")
                     {
                     }

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -237,7 +237,7 @@ table 82560 "ADLSE Setup"
         field(95; "Use Table Captions"; Boolean)
         {
             Caption = 'Use Table Captions';
-            ToolTip = 'Specifies if the captions of fields will be used instead of names.';
+            ToolTip = 'Specifies if the captions of Tables will be used instead of names.';
             InitValue = false;
         }
     }

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -224,7 +224,7 @@ table 82560 "ADLSE Setup"
         }
         field(75; "Use Field Captions"; Boolean)
         {
-            Caption = 'Use Captions';
+            Caption = 'Use Field Captions';
             ToolTip = 'Specifies if the captions of fields will be used instead of names.';
             InitValue = false;
         }
@@ -232,6 +232,12 @@ table 82560 "ADLSE Setup"
         {
             Caption = 'IDs for Duplicates Only';
             ToolTip = 'Specifies that table and field IDs will only be used in names if duplicates exist.';
+            InitValue = false;
+        }
+        field(95; "Use Table Captions"; Boolean)
+        {
+            Caption = 'Use Table Captions';
+            ToolTip = 'Specifies if the captions of fields will be used instead of names.';
             InitValue = false;
         }
     }

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -193,7 +193,8 @@ codeunit 82564 "ADLSE Util"
             if ADLSESetup."Use Field Captions" then
                 TableFields.SetRange("Field Caption", NameToUse)
             else
-                TableFields.SetRange(FieldName, NameToUse);
+                exit(GetDataLakeCompliantName(NameToUse));
+
             TableFields.SetFilter("No.", '<>%1', FieldRef.Number);
             if TableFields.IsEmpty() then // there is not a duplicate field name/caption
                 exit(GetDataLakeCompliantName(NameToUse))

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -145,12 +145,18 @@ codeunit 82564 "ADLSE Util"
         AllObjWithCaption: Record AllObjWithCaption;
         OrigTableName: Text;
     begin
-        OrigTableName := GetTableName(TableID);
         ADLSESetup.GetSingleton();
+        if ADLSESetup."Use Table Captions" then
+            OrigTableName := GetTableCaption(TableID)
+        else
+            OrigTableName := GetTableName(TableID);
         if ADLSESetup."Use IDs for Duplicates Only" then begin
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
             AllObjWithCaption.SetFilter("Object ID", '<>%1', TableID);
-            AllObjWithCaption.SetFilter("Object Name", OrigTableName);
+            if ADLSESetup."Use Table Captions" then
+                AllObjWithCaption.SetFilter("Object Caption", OrigTableName)
+            else
+                AllObjWithCaption.SetFilter("Object Name", OrigTableName);
             if AllObjWithCaption.IsEmpty() then // there is not a duplicate table caption
                 exit(GetDataLakeCompliantName(OrigTableName))
             else


### PR DESCRIPTION
Add functionality to use table captions for Open mirroring table creation alongside existing column caption functionality. A new field for "Use Table Captions" is added in the setup page with an appropriate tooltip. The code is updated to respect this setting when creating entity content and handling duplicates.

Fixes #304