### PR TITLE
Add support for Upsert operation in ADLSE table payload handling

### DIFF
--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -466,14 +466,8 @@ codeunit 82564 "ADLSE Util"
             else
                 if Deletes then
                     Payload.Append(StrSubstNo(CommaPrefixedTok, '2'))
-                else begin
-                    SystemCreatedAtNoFieldref := RecordRef.Field(RecordRef.SystemCreatedAtNo());
-                    SystemModifiedAtNoFieldref := RecordRef.Field(RecordRef.SystemModifiedAtNo());
-                    if SystemCreatedAtNoFieldref.Value() = SystemModifiedAtNoFieldref.Value() then
-                        Payload.Append(StrSubstNo(CommaPrefixedTok, '4'))
-                    else
-                        Payload.Append(StrSubstNo(CommaPrefixedTok, '4'));
-                end;
+                else
+                    Payload.Append(StrSubstNo(CommaPrefixedTok, '4'));
 
         Payload.AppendLine();
 

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -422,8 +422,6 @@ codeunit 82564 "ADLSE Util"
         ADLSESetup: Record "ADLSE Setup";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         FieldRef: FieldRef;
-        SystemCreatedAtNoFieldref: FieldRef;
-        SystemModifiedAtNoFieldref: FieldRef;
         CurrDateTime: DateTime;
         FieldID: Integer;
         FieldsAdded: Integer;

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -459,6 +459,7 @@ codeunit 82564 "ADLSE Util"
             // 0- 	Insert
             // 1- 	Update
             // 2- 	Delete
+            // 4-   Upsert
             if ADLSETableLastTimestamp.GetUpdatedLastTimestamp(RecordRef.Number) = 0 then
                 //Because of an reset always 0 is sent for the first time
                 Payload.Append(StrSubstNo(CommaPrefixedTok, '0'))
@@ -469,9 +470,9 @@ codeunit 82564 "ADLSE Util"
                     SystemCreatedAtNoFieldref := RecordRef.Field(RecordRef.SystemCreatedAtNo());
                     SystemModifiedAtNoFieldref := RecordRef.Field(RecordRef.SystemModifiedAtNo());
                     if SystemCreatedAtNoFieldref.Value() = SystemModifiedAtNoFieldref.Value() then
-                        Payload.Append(StrSubstNo(CommaPrefixedTok, '0'))
+                        Payload.Append(StrSubstNo(CommaPrefixedTok, '4'))
                     else
-                        Payload.Append(StrSubstNo(CommaPrefixedTok, '1'));
+                        Payload.Append(StrSubstNo(CommaPrefixedTok, '4'));
                 end;
 
         Payload.AppendLine();


### PR DESCRIPTION
Introduce an Upsert operation to handle cases where records need to be inserted or updated without causing data loss. This change modifies the payload handling logic to accommodate the new operation type.

Fixes #314