### PR TITLE
#321 Prevent export file number increment on deletes without upserts

### DIFF
--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -119,6 +119,7 @@ codeunit 82561 "ADLSE Execute"
         ADLSESetup: Record "ADLSE Setup";
         ADLSECommunicationDeletions: Codeunit "ADLSE Communication";
         FieldIdList: List of [Integer];
+        DidUpserts: Boolean;
     begin
         FieldIdList := CreateFieldListForTable(TableID);
 
@@ -128,12 +129,12 @@ codeunit 82561 "ADLSE Execute"
         if ADLSESetup.GetStorageType() <> ADLSESetup."Storage Type"::"Open Mirroring" then //TODO is this really needed for open mirroring?
             ADLSECommunication.CheckEntity(CDMDataFormat, EntityJsonNeedsUpdate, ManifestJsonsNeedsUpdate, false);
 
-        ExportTableUpdates(TableID, FieldIdList, ADLSECommunication, UpdatedLastTimeStamp);
+        ExportTableUpdates(TableID, FieldIdList, ADLSECommunication, UpdatedLastTimeStamp, DidUpserts);
 
         // then export the deletes
         ADLSECommunicationDeletions.Init(TableID, FieldIdList, DeletedLastEntryNo, EmitTelemetry);
         // entity has been already checked above
-        ExportTableDeletes(TableID, ADLSECommunicationDeletions, DeletedLastEntryNo);
+        ExportTableDeletes(TableID, ADLSECommunicationDeletions, DeletedLastEntryNo, DidUpserts);
     end;
 
     procedure UpdatedRecordsExist(TableID: Integer; UpdatedLastTimeStamp: BigInteger): Boolean
@@ -155,7 +156,7 @@ codeunit 82561 "ADLSE Execute"
         TimeStampFieldRef.SetFilter('>%1', UpdatedLastTimeStamp);
     end;
 
-    local procedure ExportTableUpdates(TableID: Integer; FieldIdList: List of [Integer]; ADLSECommunication: Codeunit "ADLSE Communication"; var UpdatedLastTimeStamp: BigInteger)
+    local procedure ExportTableUpdates(TableID: Integer; FieldIdList: List of [Integer]; ADLSECommunication: Codeunit "ADLSE Communication"; var UpdatedLastTimeStamp: BigInteger; var DidUpserts: Boolean)
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSESeekData: Report "ADLSE Seek Data";
@@ -190,6 +191,7 @@ codeunit 82561 "ADLSE Execute"
 
         RecordRef.ReadIsolation := RecordRef.ReadIsolation::ReadCommitted;
         if ADLSESeekData.FindRecords(RecordRef) then begin
+            DidUpserts := true;
             if EmitTelemetry then begin
                 TableCaption := RecordRef.Caption();
                 EntityCount := Format(RecordRef.Count());
@@ -255,7 +257,7 @@ codeunit 82561 "ADLSE Execute"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Deleted Record", 'r')]
-    local procedure ExportTableDeletes(TableID: Integer; ADLSECommunication: Codeunit "ADLSE Communication"; var DeletedLastEntryNo: BigInteger)
+    local procedure ExportTableDeletes(TableID: Integer; ADLSECommunication: Codeunit "ADLSE Communication"; var DeletedLastEntryNo: BigInteger; DidUpserts: Boolean)
     var
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
         ADLSESetup: Record "ADLSE Setup";
@@ -278,11 +280,12 @@ codeunit 82561 "ADLSE Execute"
         ADLSEDeletedRecord.ReadIsolation := ADLSEDeletedRecord.ReadIsolation::ReadCommitted;
         if ADLSESeekData.FindRecords(ADLSEDeletedRecord) then begin
             //Addin the number when open mirroring is used
-            if (ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring") then begin
-                ADLSETable.Get(TableID);
-                ADLSETable.ExportFileNumber := ADLSETable.ExportFileNumber + 1;
-                ADLSETable.Modify(true);
-            end;
+            if DidUpserts then
+                if (ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring") then begin
+                    ADLSETable.Get(TableID);
+                    ADLSETable.ExportFileNumber := ADLSETable.ExportFileNumber + 1;
+                    ADLSETable.Modify(true);
+                end;
             RecordRef.Open(ADLSEDeletedRecord."Table ID");
 
             FixDeletedRecordThatAreInTable(ADLSEDeletedRecord);


### PR DESCRIPTION
Enhance the ADLSE Execute codeunit to track upserts during export operations for Open Mirroring. This change ensures that the export file number only increments when there have been upserts prior to deletes, preventing unnecessary increments when only deletes occur.

Fixes #321