### PR TITLE
#322 Enhance deletion handling for company-specific resets in Open Mirroring

### DIFF
--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -205,6 +205,7 @@ table 82561 "ADLSE Table"
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         ADLSESetup: Record "ADLSE Setup";
+        Company: Record Company;
         ADLSECommunication: Codeunit "ADLSE Communication";
         Counter: Integer;
     begin
@@ -236,8 +237,20 @@ table 82561 "ADLSE Table"
                         ADLSETableLastTimestamp.ModifyAll("Deleted Last Entry No.", 0);
                         ADLSETableLastTimestamp.SetRange("Table ID");
                     end;
-                ADLSEDeletedRecord.SetRange("Table ID", Rec."Table ID");
-                ADLSEDeletedRecord.DeleteAll(false);
+                if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then begin
+                    Company.Reset();
+                    if Company.FindSet() then
+                        repeat
+                            ADLSEDeletedRecord.Reset();
+                            ADLSEDeletedRecord.ChangeCompany(Company.Name);  // clear deletion table for all companies.
+                            ADLSEDeletedRecord.SetRange("Table ID", Rec."Table ID");
+                            ADLSEDeletedRecord.DeleteAll(false);
+                        until Company.Next() < 1;
+                end
+                else begin
+                    ADLSEDeletedRecord.SetRange("Table ID", Rec."Table ID");
+                    ADLSEDeletedRecord.DeleteAll(false);
+                end;
 
                 if (ADLSESetup."Delete Table") then
                     ADLSECommunication.ResetTableExport(Rec."Table ID", AllCompanies);

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -466,9 +466,14 @@ codeunit 82564 "ADLSE Util"
             // 1- 	Update
             // 2- 	Delete
             // 4-   Upsert
-            if ADLSETableLastTimestamp.GetUpdatedLastTimestamp(RecordRef.Number) = 0 then
+             if not ADLSETableLastTimestamp.ExistsUpdatedLastTimestamp(RecordRef.Number) then begin
                 //Because of an reset always 0 is sent for the first time
-                Payload.Append(StrSubstNo(CommaPrefixedTok, '0'))
+                //UPDATED -- On reset No record will exist if it is the first Run. (Gets deleted On reset)
+                if Deletes then// just a catch deletes To prevent Export to 'Insert' Deletes at All times
+                    Payload.Append(StrSubstNo(CommaPrefixedTok, '2'))
+                else
+                    Payload.Append(StrSubstNo(CommaPrefixedTok, '0'));
+            end
             else
                 if Deletes then
                     Payload.Append(StrSubstNo(CommaPrefixedTok, '2'))


### PR DESCRIPTION
Improve the deletion process in the ADLSE Table to ensure that resetting a table deletes records for all companies when using the Open Mirroring storage type. Additionally, refine the timestamp checks in the ADLSE Util codeunit to prevent incorrect exports of deleted records as inserts during the first run. This addresses inconsistencies in deletion tracking and enhances overall data integrity.

Fixes #322