### PR TITLE
Add file detection strategy to entity content creation for mirroring

### DIFF
--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -68,6 +68,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
         if ADLSEUtil.IsTablePerCompany(TableID) then
             Imports.Add(this.GetCompanyFieldName());
         Content.Add('keyColumns', Imports);
+        Content.Add('fileDetectionStrategy', 'LastUpdateTimeFileDetection');
 
         ADLSESetup.GetSingleton();
         foreach FieldId in FieldIdList do begin


### PR DESCRIPTION
Nonsequential files are also supported; files will be read based on their timestamp.
Added "fileDetectionStrategy": LastUpdateTimeFileDetection to _metadata.json