### PR TITLE
ADLSE Execute/ExternalEvents: only fire export-finished when last session ends; remove obsolete handlers

### DIFF
--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -94,8 +94,6 @@ codeunit 82561 "ADLSE Execute"
                 ADLSEExecution.Log('ADLSE-005', 'Export completed without error', Verbosity::Normal, CustomDimensions)
             else
                 ADLSEExecution.Log('ADLSE-040', 'Export completed with errors', Verbosity::Warning, CustomDimensions);
-
-        ADLSEExternalEvents.OnAllExportIsFinished(ADLSESetup);
     end;
 
     var
@@ -239,7 +237,7 @@ codeunit 82561 "ADLSE Execute"
                         ADLSEExecution.Log('ADLSE-023', 'Skipping record in delay window', Verbosity::Normal, CustomDimensions);
                     end;
 
-                if CollectedAndSent then 
+                if CollectedAndSent then
                     NoMoreToCollect := RecordRef.Next() = 0;
             until (not CollectedAndSent or NoMoreToCollect);
 
@@ -401,12 +399,15 @@ codeunit 82561 "ADLSE Execute"
         // batch. 
         ADLSESessionManager.StartExportFromPendingTables();
 
-        ADLSESetupRec.GetSingleton();
-        ADLSEExternalEvents.OnExportFinished(ADLSESetupRec, ADLSETable);
 
-        if not ADLSECurrentSession.AreAnySessionsActive() then
+
+        if not ADLSECurrentSession.AreAnySessionsActive() then begin
+            ADLSESetupRec.GetSingleton();
+            ADLSEExternalEvents.OnExportFinished(ADLSESetupRec, ADLSETable);
+
             if EmitTelemetry then
                 ADLSEExecution.Log('ADLSE-041', 'All exports are finished', Verbosity::Normal);
+        end;
     end;
 
     procedure UpdateInProgressTableTimestamp(var Rec: Record "ADLSE Table"; LastTimestamp: BigInteger; Deletes: Boolean)
@@ -439,7 +440,7 @@ codeunit 82561 "ADLSE Execute"
                     exit;
                 end;
         end;
-        
+
         if TimestampUpdated then
             if EmitTelemetry then begin
                 Clear(CustomDimensions);

--- a/businessCentral/app/src/ExternalEvents.Codeunit.al
+++ b/businessCentral/app/src/ExternalEvents.Codeunit.al
@@ -105,20 +105,6 @@ codeunit 82574 "ADLSE External Events"
         MyBusinessOnExport(ADLSESetup.SystemId, ADLSESetup."Storage Type", Url, WebClientUrl);
     end;
 
-    [Obsolete('Replaced with the OnExportFinishedv2 External Business Event', '24.0')]
-    internal procedure OnExportFinished(ADLSESetup: Record "ADLSE Setup")
-    var
-        Url: Text[250];
-        WebClientUrl: Text[250];
-        ADLSEFieldApiUrlTok: Label 'bc2adlsTeamMicrosoft/bc2adls/v1.0/companies(%1)/adlseSetup(%2)', Locked = true;
-    begin
-        Url := ADLSEExternalEventsHelper.CreateLink(ADLSEFieldApiUrlTok, ADLSESetup.SystemId);
-        WebClientUrl := CopyStr(GetUrl(ClientType::Web, CompanyName(), ObjectType::Page, Page::"ADLSE Setup", ADLSESetup), 1, MaxStrLen(WebClientUrl));
-#pragma warning disable AL0432
-        MyBusinessOnExportFinished(ADLSESetup.SystemId, ADLSESetup."Storage Type", Url, WebClientUrl);
-#pragma warning restore AL0432
-    end;
-
     internal procedure OnExportFinished(ADLSESetup: Record "ADLSE Setup"; ADLSETable: Record "ADLSE Table")
     var
         Url: Text[250];
@@ -127,7 +113,7 @@ codeunit 82574 "ADLSE External Events"
     begin
         Url := ADLSEExternalEventsHelper.CreateLink(ADLSEFieldApiUrlTok, ADLSETable.SystemId);
         WebClientUrl := CopyStr(GetUrl(ClientType::Web, CompanyName(), ObjectType::Page, Page::"ADLSE Setup", ADLSESetup), 1, MaxStrLen(WebClientUrl));
-        MyBusinessOnExportFinishedv2(ADLSETable.SystemId, ADLSESetup."Storage Type", ADLSETable."Table ID", Url, WebClientUrl);
+        MyBusinessOnAllExportIsFinished(ADLSESetup.SystemId, ADLSESetup."Storage Type", Url, WebClientUrl);
     end;
 
     internal procedure OnAllExportIsFinished(ADLSESetup: Record "ADLSE Setup")
@@ -214,17 +200,6 @@ codeunit 82574 "ADLSE External Events"
 
     [ExternalBusinessEvent('OnExport', 'Export data', 'When the data is exported', EventCategory::ADLSE)]
     local procedure MyBusinessOnExport(SystemId: Guid; "Storage Type": Enum "ADLSE Storage Type"; Url: Text[250]; WebClientUrl: Text[250])
-    begin
-    end;
-
-    [Obsolete('Replaced with the OnExportFinishedv2 External Business Event', '24.0')]
-    [ExternalBusinessEvent('OnExportFinished', 'Export is finished for one table', 'When the export is finished for one table', EventCategory::ADLSE)]
-    local procedure MyBusinessOnExportFinished(SystemId: Guid; "Storage Type": Enum "ADLSE Storage Type"; Url: Text[250]; WebClientUrl: Text[250])
-    begin
-    end;
-
-    [ExternalBusinessEvent('OnExportFinishedv2', 'Export is finished for one table v2', 'When the export is finished for one table', EventCategory::ADLSE)]
-    local procedure MyBusinessOnExportFinishedv2(SystemId: Guid; "Storage Type": Enum "ADLSE Storage Type"; TableId: Integer; Url: Text[250]; WebClientUrl: Text[250])
     begin
     end;
 


### PR DESCRIPTION
- Call OnExportFinished (external event) only when no ADLSE sessions are active to avoid duplicate notifications.
- Remove obsolete OnExportFinished and OnExportFinishedv2 business-event stubs and related legacy code.
- Consolidate event invocation to use OnAllExportIsFinished where appropriate.
- Minor formatting/whitespace cleanups.