### PR TITLE
Refactor SetToken to clear cache before writing to avoid "record alre…

### DIFF
--- a/businessCentral/app/src/TokenCache.Codeunit.al
+++ b/businessCentral/app/src/TokenCache.Codeunit.al
@@ -40,22 +40,15 @@ codeunit 82580 "ADLSE Token Cache"
     [NonDebuggable]
     procedure SetToken(Token: Text; ExpiresAt: DateTime)
     begin
-        // Guard against concurrent sessions attempting to insert the same key simultaneously.
-        // IsolatedStorage.Set does INSERT when the key is not yet visible in this session,
-        // so a concurrent committed insert by another session causes "record already exists".
-        // Note: On BC On-Premises, DisableWriteInsideTryFunctions is True by default,
-        // which blocks database writes (incl. IsolatedStorage) in TryFunction procedures.
-        // Set it to False in the server configuration if you encounter token cache errors.
-        // See https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-handling-errors-using-try-methods
-        if not TryWriteToCache(Token, ExpiresAt) then begin
-            ClearCache();
-            if not TryWriteToCache(Token, ExpiresAt) then;
-        end;
+        // Clear any existing cache entries before writing to avoid "record already exists"
+        // errors from concurrent sessions. Deleting first ensures IsolatedStorage.Set always
+        // performs an INSERT on a clean state, which is safe on both SaaS and On-Premises.
+        ClearCache();
+        WriteToCache(Token, ExpiresAt);
     end;
 
-    [TryFunction]
     [NonDebuggable]
-    local procedure TryWriteToCache(Token: Text; ExpiresAt: DateTime)
+    local procedure WriteToCache(Token: Text; ExpiresAt: DateTime)
     begin
 #pragma warning disable LC0043
         IsolatedStorage.Set(AccessTokenKeyNameTok, Token, DataScope::Module);


### PR DESCRIPTION
…ady exists" errors

Fixes #489