### PR TITLE
feat: Custom key columns (Primary Key) for Open Mirroring

### DIFF
--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -53,14 +53,15 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
     procedure CreateEntityContent(TableID: Integer) Content: JsonObject
     var
         ADLSESetup: Record "ADLSE Setup";
-        FieldTable: Record Field;
         ADLSEUtil: Codeunit "ADLSE Util";
         ADLSEExecute: Codeunit "ADLSE Execute";
         RecordRef: RecordRef;
+        KeyRef: KeyRef;
         SystemIdFieldRef: FieldRef;
         FieldRef: FieldRef;
         FieldIdList: List of [Integer];
         FieldId: Integer;
+        i: Integer;
         Imports: JsonArray;
         Columns: JsonArray;
         Column: JsonObject;
@@ -72,14 +73,12 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
         ADLSESetup.GetSingleton();
 
         if ADLSESetup."Use Primary Key for Mirroring" then begin
-            // Use the table's primary key fields as key columns
-            FieldTable.SetRange(TableNo, TableID);
-            FieldTable.SetRange(IsPartOfPrimaryKey, true);
-            if FieldTable.FindSet() then
-                repeat
-                    FieldRef := RecordRef.Field(FieldTable."No.");
-                    Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
-                until FieldTable.Next() = 0;
+            // Use the table's primary key fields as key columns, preserving declared PK order
+            KeyRef := RecordRef.KeyIndex(1);
+            for i := 1 to KeyRef.FieldCount() do begin
+                FieldRef := KeyRef.FieldIndex(i);
+                Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
+            end;
         end else begin
             // Default: use SystemId as key column
             SystemIdFieldRef := RecordRef.Field(2000000000);

--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -53,6 +53,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
     procedure CreateEntityContent(TableID: Integer) Content: JsonObject
     var
         ADLSESetup: Record "ADLSE Setup";
+        FieldTable: Record Field;
         ADLSEUtil: Codeunit "ADLSE Util";
         ADLSEExecute: Codeunit "ADLSE Execute";
         RecordRef: RecordRef;
@@ -65,25 +66,42 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
         Column: JsonObject;
         SchemaDefinition: JsonObject;
     begin
-        //Must be systemId and $Company because of the deleted record table
         RecordRef.Open(TableID);
         FieldIdList := ADLSEExecute.CreateFieldListForTable(TableID);
 
-        SystemIdFieldRef := RecordRef.Field(2000000000);
-        Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(SystemIdFieldRef));
+        ADLSESetup.GetSingleton();
+
+        if ADLSESetup."Use Primary Key for Mirroring" then begin
+            // Use the table's primary key fields as key columns
+            FieldTable.SetRange(TableNo, TableID);
+            FieldTable.SetRange(IsPartOfPrimaryKey, true);
+            if FieldTable.FindSet() then
+                repeat
+                    FieldRef := RecordRef.Field(FieldTable."No.");
+                    Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
+                until FieldTable.Next() = 0;
+        end else begin
+            // Default: use SystemId as key column
+            SystemIdFieldRef := RecordRef.Field(2000000000);
+            Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(SystemIdFieldRef));
+        end;
         if ADLSEUtil.IsTablePerCompany(TableID) then
             Imports.Add(this.GetCompanyFieldName());
         Content.Add('keyColumns', Imports);
         Content.Add('fileDetectionStrategy', 'LastUpdateTimeFileDetection');
 
-        ADLSESetup.GetSingleton();
         foreach FieldId in FieldIdList do begin
             FieldRef := RecordRef.Field(FieldId);
             Clear(Column);
             Column.Add('Name', ADLSEUtil.GetDataLakeCompliantFieldName(FieldRef));
             Column.Add('DataType', GetOpenMirrorDataFormat(FieldRef.Type()));
-            if (FieldRef.Number() <> RecordRef.SystemIdNo()) then
-                Column.Add('IsNullable', true);
+            if ADLSESetup."Use Primary Key for Mirroring" then begin
+                if not IsPrimaryKeyField(TableID, FieldId) then
+                    Column.Add('IsNullable', true);
+            end else begin
+                if (FieldRef.Number() <> RecordRef.SystemIdNo()) then
+                    Column.Add('IsNullable', true);
+            end;
             Columns.Add(Column);
         end;
 

--- a/businessCentral/app/src/CDMUtil.Codeunit.al
+++ b/businessCentral/app/src/CDMUtil.Codeunit.al
@@ -81,7 +81,7 @@ codeunit 82566 "ADLSE CDM Util" // Refer Common Data Model https://docs.microsof
             end;
         end else begin
             // Default: use SystemId as key column
-            SystemIdFieldRef := RecordRef.Field(2000000000);
+            SystemIdFieldRef := RecordRef.Field(RecordRef.SystemIdNo());
             Imports.Add(ADLSEUtil.GetDataLakeCompliantFieldName(SystemIdFieldRef));
         end;
         if ADLSEUtil.IsTablePerCompany(TableID) then

--- a/businessCentral/app/src/DeletedRecord.Table.al
+++ b/businessCentral/app/src/DeletedRecord.Table.al
@@ -32,6 +32,11 @@ table 82563 "ADLSE Deleted Record"
             Editable = false;
             Caption = 'Deletion Timestamp';
         }
+        field(5; "Primary Key Values"; Text[2048])
+        {
+            Editable = false;
+            Caption = 'Primary Key Values';
+        }
     }
 
     keys
@@ -61,6 +66,11 @@ table 82563 "ADLSE Deleted Record"
         ADLSEUtil: Codeunit "ADLSE Util";
         SystemIdFieldRef: FieldRef;
         TimestampFieldRef: FieldRef;
+        PKFieldRef: FieldRef;
+        KeyRef: KeyRef;
+        PKValues: JsonObject;
+        PKText: Text;
+        i: Integer;
     begin
         if RecordRef.IsTemporary() then
             exit;
@@ -72,11 +82,11 @@ table 82563 "ADLSE Deleted Record"
         if IsNullGuid(SystemIdFieldRef.Value()) then
             exit;
 
+        ADLSESetup.GetSingleton();
+
         //Handle deletes in table on tenant level and deleted in another company
-        if not ADLSEUtil.IsTablePerCompany(RecordRef.Number()) then begin
-            ADLSESetup.GetSingleton();
+        if not ADLSEUtil.IsTablePerCompany(RecordRef.Number()) then
             ChangeCompany(ADLSESetup."Export Company Database Tables");
-        end;
 
         // Do not log a deletion if its for a record that is created after the last sync
         // TODO: This requires tracking the SystemModifiedAt of the last time stamp 
@@ -91,6 +101,17 @@ table 82563 "ADLSE Deleted Record"
         TimestampFieldRef := RecordRef.Field(0);
         "Deletion Timestamp" := TimestampFieldRef.Value();
         "Deletion Timestamp" += 1; // to mark an update that is greater than the last time stamp on this record
+
+        if ADLSESetup."Use Primary Key for Mirroring" then begin
+            KeyRef := RecordRef.KeyIndex(1);
+            for i := 1 to KeyRef.FieldCount() do begin
+                PKFieldRef := KeyRef.FieldIndex(i);
+                PKValues.Add(Format(PKFieldRef.Number()), Format(PKFieldRef.Value(), 0, 9));
+            end;
+            PKValues.WriteTo(PKText);
+            "Primary Key Values" := CopyStr(PKText, 1, MaxStrLen("Primary Key Values"));
+        end;
+
         Insert();
     end;
 }

--- a/businessCentral/app/src/DeletedRecord.Table.al
+++ b/businessCentral/app/src/DeletedRecord.Table.al
@@ -71,6 +71,7 @@ table 82563 "ADLSE Deleted Record"
         PKValues: JsonObject;
         PKText: Text;
         i: Integer;
+        PrimaryKeyValuesTooLongErr: Label 'Primary key values for table %1 exceed the maximum supported length of %2 characters.', Comment = '%1 = Table number, %2 = Max length';
     begin
         if RecordRef.IsTemporary() then
             exit;
@@ -109,7 +110,9 @@ table 82563 "ADLSE Deleted Record"
                 PKValues.Add(Format(PKFieldRef.Number()), Format(PKFieldRef.Value(), 0, 9));
             end;
             PKValues.WriteTo(PKText);
-            "Primary Key Values" := CopyStr(PKText, 1, MaxStrLen("Primary Key Values"));
+            if StrLen(PKText) > MaxStrLen("Primary Key Values") then
+                Error(PrimaryKeyValuesTooLongErr, RecordRef.Number(), MaxStrLen("Primary Key Values"));
+            "Primary Key Values" := PKText;
         end;
 
         Insert();

--- a/businessCentral/app/src/DeletedRecord.Table.al
+++ b/businessCentral/app/src/DeletedRecord.Table.al
@@ -71,7 +71,6 @@ table 82563 "ADLSE Deleted Record"
         PKValues: JsonObject;
         PKText: Text;
         i: Integer;
-        PrimaryKeyValuesTooLongErr: Label 'Primary key values for table %1 exceed the maximum supported length of %2 characters.', Comment = '%1 = Table number, %2 = Max length';
     begin
         if RecordRef.IsTemporary() then
             exit;
@@ -110,9 +109,8 @@ table 82563 "ADLSE Deleted Record"
                 PKValues.Add(Format(PKFieldRef.Number()), Format(PKFieldRef.Value(), 0, 9));
             end;
             PKValues.WriteTo(PKText);
-            if StrLen(PKText) > MaxStrLen("Primary Key Values") then
-                Error(PrimaryKeyValuesTooLongErr, RecordRef.Number(), MaxStrLen("Primary Key Values"));
-            "Primary Key Values" := PKText;
+            if StrLen(PKText) <= MaxStrLen("Primary Key Values") then
+                "Primary Key Values" := PKText;
         end;
 
         Insert();

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -138,9 +138,16 @@ page 82560 "ADLSE Setup"
                     Editable = FabricOpenMirroring;
 
                     trigger OnValidate()
+                    var
+                        ADLSETable: Record "ADLSE Table";
                     begin
-                        if Rec."Use Primary Key for Mirroring" then
-                            Message(UsePrimaryKeyForMirroringResetTablesMsg);
+                        if not Confirm(UsePrimaryKeyForMirroringConfirmQst) then begin
+                            Rec."Use Primary Key for Mirroring" := xRec."Use Primary Key for Mirroring";
+                            exit;
+                        end;
+                        Rec."Schema Exported On" := 0DT;
+                        ADLSETable.Reset();
+                        ADLSETable.ResetSelected();
                     end;
                 }
             }
@@ -448,7 +455,7 @@ page 82560 "ADLSE Setup"
         OldLogsExist: Boolean;
         FailureNotificationID: Guid;
         ExportFailureNotificationMsg: Label 'Data from one or more tables failed to export on the last run. Please check the tables below to see the error(s).';
-        UsePrimaryKeyForMirroringResetTablesMsg: Label 'Best practice: after enabling ''Use Primary Key for Mirroring'', reset all tables so the Open Mirroring schema is regenerated with the new key columns.';
+        UsePrimaryKeyForMirroringConfirmQst: Label 'Changing this setting requires clearing the exported schema and resetting all tables. All data will be re-exported from scratch on the next run. Do you want to continue?';
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'r')]
     local procedure UpdateNotificationIfAnyTableExportFailed()

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -136,6 +136,12 @@ page 82560 "ADLSE Setup"
                 {
                     Importance = Additional;
                     Editable = FabricOpenMirroring;
+
+                    trigger OnValidate()
+                    begin
+                        if Rec."Use Primary Key for Mirroring" then
+                            Message(UsePrimaryKeyForMirroringResetTablesMsg);
+                    end;
                 }
             }
 
@@ -442,6 +448,7 @@ page 82560 "ADLSE Setup"
         OldLogsExist: Boolean;
         FailureNotificationID: Guid;
         ExportFailureNotificationMsg: Label 'Data from one or more tables failed to export on the last run. Please check the tables below to see the error(s).';
+        UsePrimaryKeyForMirroringResetTablesMsg: Label 'Best practice: after enabling ''Use Primary Key for Mirroring'', reset all tables so the Open Mirroring schema is regenerated with the new key columns.';
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'r')]
     local procedure UpdateNotificationIfAnyTableExportFailed()

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -132,6 +132,11 @@ page 82560 "ADLSE Setup"
                 {
                     Importance = Additional;
                 }
+                field("Use Primary Key for Mirroring"; Rec."Use Primary Key for Mirroring")
+                {
+                    Importance = Additional;
+                    Visible = FabricOpenMirroring;
+                }
             }
 
             group(DataFormatSettings)

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -135,7 +135,7 @@ page 82560 "ADLSE Setup"
                 field("Use Primary Key for Mirroring"; Rec."Use Primary Key for Mirroring")
                 {
                     Importance = Additional;
-                    Visible = FabricOpenMirroring;
+                    Editable = FabricOpenMirroring;
                 }
             }
 

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -229,11 +229,6 @@ table 82560 "ADLSE Setup"
             ToolTip = 'Specifies if the primary key fields of tables should be used as key columns in the Open Mirroring metadata instead of SystemId. Enable this if records are recreated with new SystemIds causing duplicates in the mirrored database.';
             InitValue = false;
 
-            trigger OnValidate()
-            begin
-                if Rec."Schema Exported On" <> 0DT then
-                    Error(ErrorInfo.Create(SchemaAlreadyExportedErr, true));
-            end;
         }
     }
 

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -223,6 +223,18 @@ table 82560 "ADLSE Setup"
             ToolTip = 'Specifies if you want to export the closing date column in G/L Entries.';
             InitValue = false;
         }
+        field(85; "Use Primary Key for Mirroring"; Boolean)
+        {
+            Caption = 'Use Primary Key for Mirroring';
+            ToolTip = 'Specifies if the primary key fields of tables should be used as key columns in the Open Mirroring metadata instead of SystemId. Enable this if records are recreated with new SystemIds causing duplicates in the mirrored database.';
+            InitValue = false;
+
+            trigger OnValidate()
+            begin
+                if Rec."Schema Exported On" <> 0DT then
+                    Error(ErrorInfo.Create(SchemaAlreadyExportedErr, true));
+            end;
+        }
     }
 
     keys

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -532,6 +532,10 @@ codeunit 82564 "ADLSE Util"
         TimestampFieldRef: FieldRef;
         SystemIdFieldRef: FieldRef;
         SystemDateFieldRef: FieldRef;
+        PKFieldRef: FieldRef;
+        PKValues: JsonObject;
+        FieldNoText: Text;
+        FieldNo: Integer;
     begin
         TimestampFieldRef := RecordRef.Field(0);
         TimestampFieldRef.Value(ADLSEDeletedRecord."Deletion Timestamp");
@@ -542,6 +546,63 @@ codeunit 82564 "ADLSE Util"
         SystemDateFieldRef.Value(0DT);
         SystemDateFieldRef := RecordRef.Field(RecordRef.SystemModifiedAtNo());
         SystemDateFieldRef.Value(0DT);
+
+        if ADLSEDeletedRecord."Primary Key Values" <> '' then begin
+            PKValues.ReadFrom(ADLSEDeletedRecord."Primary Key Values");
+            foreach FieldNoText in PKValues.Keys() do begin
+                Evaluate(FieldNo, FieldNoText);
+                PKFieldRef := RecordRef.Field(FieldNo);
+                SetFieldRefValueFromText(PKFieldRef, GetTextValueForKeyInJson(PKValues, FieldNoText));
+            end;
+        end;
+    end;
+
+    local procedure SetFieldRefValueFromText(var PKFieldRef: FieldRef; TextValue: Text)
+    var
+        IntValue: Integer;
+        BigIntValue: BigInteger;
+        DecimalValue: Decimal;
+        GuidValue: Guid;
+        DateValue: Date;
+        BoolValue: Boolean;
+    begin
+        case PKFieldRef.Type() of
+            PKFieldRef.Type::Integer:
+                begin
+                    Evaluate(IntValue, TextValue, 9);
+                    PKFieldRef.Value(IntValue);
+                end;
+            PKFieldRef.Type::BigInteger:
+                begin
+                    Evaluate(BigIntValue, TextValue, 9);
+                    PKFieldRef.Value(BigIntValue);
+                end;
+            PKFieldRef.Type::Decimal:
+                begin
+                    Evaluate(DecimalValue, TextValue, 9);
+                    PKFieldRef.Value(DecimalValue);
+                end;
+            PKFieldRef.Type::Boolean:
+                begin
+                    Evaluate(BoolValue, TextValue, 9);
+                    PKFieldRef.Value(BoolValue);
+                end;
+            PKFieldRef.Type::Guid:
+                begin
+                    Evaluate(GuidValue, TextValue);
+                    PKFieldRef.Value(GuidValue);
+                end;
+            PKFieldRef.Type::Date:
+                begin
+                    Evaluate(DateValue, TextValue, 9);
+                    PKFieldRef.Value(DateValue);
+                end;
+            PKFieldRef.Type::Code,
+            PKFieldRef.Type::Text:
+                PKFieldRef.Value(TextValue);
+            else
+                PKFieldRef.Value(TextValue);
+        end;
     end;
 
     internal procedure GetTextValueForKeyInJson(Object: JsonObject; "Key": Text): Text

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -547,14 +547,14 @@ codeunit 82564 "ADLSE Util"
         SystemDateFieldRef := RecordRef.Field(RecordRef.SystemModifiedAtNo());
         SystemDateFieldRef.Value(0DT);
 
-        if ADLSEDeletedRecord."Primary Key Values" <> '' then begin
-            PKValues.ReadFrom(ADLSEDeletedRecord."Primary Key Values");
-            foreach FieldNoText in PKValues.Keys() do begin
-                Evaluate(FieldNo, FieldNoText);
-                PKFieldRef := RecordRef.Field(FieldNo);
-                SetFieldRefValueFromText(PKFieldRef, GetTextValueForKeyInJson(PKValues, FieldNoText));
-            end;
-        end;
+        if ADLSEDeletedRecord."Primary Key Values" <> '' then
+            if PKValues.ReadFrom(ADLSEDeletedRecord."Primary Key Values") then
+                foreach FieldNoText in PKValues.Keys() do
+                    if Evaluate(FieldNo, FieldNoText) then
+                        if RecordRef.FieldExist(FieldNo) then begin
+                            PKFieldRef := RecordRef.Field(FieldNo);
+                            SetFieldRefValueFromText(PKFieldRef, GetTextValueForKeyInJson(PKValues, FieldNoText));
+                        end;
     end;
 
     local procedure SetFieldRefValueFromText(var PKFieldRef: FieldRef; TextValue: Text)
@@ -564,15 +564,20 @@ codeunit 82564 "ADLSE Util"
         DecimalValue: Decimal;
         GuidValue: Guid;
         DateValue: Date;
+        DateTimeValue: DateTime;
+        TimeValue: Time;
+        DateFormulaValue: DateFormula;
         BoolValue: Boolean;
     begin
         case PKFieldRef.Type() of
-            PKFieldRef.Type::Integer:
+            PKFieldRef.Type::Integer,
+            PKFieldRef.Type::Option:
                 begin
                     Evaluate(IntValue, TextValue, 9);
                     PKFieldRef.Value(IntValue);
                 end;
-            PKFieldRef.Type::BigInteger:
+            PKFieldRef.Type::BigInteger,
+            PKFieldRef.Type::Duration:
                 begin
                     Evaluate(BigIntValue, TextValue, 9);
                     PKFieldRef.Value(BigIntValue);
@@ -596,6 +601,21 @@ codeunit 82564 "ADLSE Util"
                 begin
                     Evaluate(DateValue, TextValue, 9);
                     PKFieldRef.Value(DateValue);
+                end;
+            PKFieldRef.Type::DateTime:
+                begin
+                    Evaluate(DateTimeValue, TextValue, 9);
+                    PKFieldRef.Value(DateTimeValue);
+                end;
+            PKFieldRef.Type::Time:
+                begin
+                    Evaluate(TimeValue, TextValue, 9);
+                    PKFieldRef.Value(TimeValue);
+                end;
+            PKFieldRef.Type::DateFormula:
+                begin
+                    Evaluate(DateFormulaValue, TextValue, 9);
+                    PKFieldRef.Value(DateFormulaValue);
                 end;
             PKFieldRef.Type::Code,
             PKFieldRef.Type::Text:

--- a/businessCentral/app/src/Util.Codeunit.al
+++ b/businessCentral/app/src/Util.Codeunit.al
@@ -557,7 +557,7 @@ codeunit 82564 "ADLSE Util"
                         end;
     end;
 
-    local procedure SetFieldRefValueFromText(var PKFieldRef: FieldRef; TextValue: Text)
+    local procedure SetFieldRefValueFromText(var PKFieldRef: FieldRef; TextValue: Text): Boolean
     var
         IntValue: Integer;
         BigIntValue: BigInteger;
@@ -573,56 +573,66 @@ codeunit 82564 "ADLSE Util"
             PKFieldRef.Type::Integer,
             PKFieldRef.Type::Option:
                 begin
-                    Evaluate(IntValue, TextValue, 9);
+                    if not Evaluate(IntValue, TextValue, 9) then
+                        exit(false);
                     PKFieldRef.Value(IntValue);
                 end;
             PKFieldRef.Type::BigInteger,
             PKFieldRef.Type::Duration:
                 begin
-                    Evaluate(BigIntValue, TextValue, 9);
+                    if not Evaluate(BigIntValue, TextValue, 9) then
+                        exit(false);
                     PKFieldRef.Value(BigIntValue);
                 end;
             PKFieldRef.Type::Decimal:
                 begin
-                    Evaluate(DecimalValue, TextValue, 9);
+                    if not Evaluate(DecimalValue, TextValue, 9) then
+                        exit(false);
                     PKFieldRef.Value(DecimalValue);
                 end;
             PKFieldRef.Type::Boolean:
                 begin
-                    Evaluate(BoolValue, TextValue, 9);
+                    if not Evaluate(BoolValue, TextValue, 9) then
+                        exit(false);
                     PKFieldRef.Value(BoolValue);
                 end;
             PKFieldRef.Type::Guid:
                 begin
-                    Evaluate(GuidValue, TextValue);
+                    if not Evaluate(GuidValue, TextValue) then
+                        exit(false);
                     PKFieldRef.Value(GuidValue);
                 end;
             PKFieldRef.Type::Date:
                 begin
-                    Evaluate(DateValue, TextValue, 9);
+                    if not Evaluate(DateValue, TextValue, 9) then
+                        exit(false);
                     PKFieldRef.Value(DateValue);
                 end;
             PKFieldRef.Type::DateTime:
                 begin
-                    Evaluate(DateTimeValue, TextValue, 9);
+                    if not Evaluate(DateTimeValue, TextValue, 9) then
+                        exit(false);
                     PKFieldRef.Value(DateTimeValue);
                 end;
             PKFieldRef.Type::Time:
                 begin
-                    Evaluate(TimeValue, TextValue, 9);
+                    if not Evaluate(TimeValue, TextValue, 9) then
+                        exit(false);
                     PKFieldRef.Value(TimeValue);
                 end;
             PKFieldRef.Type::DateFormula:
                 begin
-                    Evaluate(DateFormulaValue, TextValue, 9);
+                    if not Evaluate(DateFormulaValue, TextValue, 9) then
+                        exit(false);
                     PKFieldRef.Value(DateFormulaValue);
                 end;
             PKFieldRef.Type::Code,
             PKFieldRef.Type::Text:
                 PKFieldRef.Value(TextValue);
             else
-                PKFieldRef.Value(TextValue);
+                exit(false);
         end;
+        exit(true);
     end;
 
     internal procedure GetTextValueForKeyInJson(Object: JsonObject; "Key": Text): Text

--- a/businessCentral/test/src/CDMUtilTests.Codeunit.al
+++ b/businessCentral/test/src/CDMUtilTests.Codeunit.al
@@ -402,6 +402,125 @@ codeunit 85569 "ADLSE CDM Util Tests"
         LibraryAssert.IsTrue(IsPK, 'Code field should be a primary key field');
     end;
 
+    [Test]
+    procedure TestCreateEntityContent_OpenMirroring_DefaultUsesSystemId()
+    var
+        ADLSETable: Record "ADLSE Table";
+        ADLSECDMUtil: Codeunit "ADLSE CDM Util";
+        EntityContent: JsonObject;
+        Token: JsonToken;
+        KeyColumns: JsonArray;
+        JsonText: Text;
+    begin
+        // [SCENARIO] Open Mirroring CreateEntityContent uses SystemId as keyColumn by default
+        // [GIVEN] Open Mirroring setup without PK mirroring enabled
+        Initialize();
+        ADLSELibrarybc2adls.CleanUp();
+        ADLSELibrarybc2adls.CreateAdlseSetup("Storage Type"::"Open Mirroring");
+        ADLSETable.Add(Database::"Reason Code");
+        ADLSELibrarybc2adls.InsertFields();
+        ADLSELibrarybc2adls.EnableFields();
+
+        // [WHEN] CreateEntityContent is called (Open Mirroring overload)
+        EntityContent := ADLSECDMUtil.CreateEntityContent(Database::"Reason Code");
+
+        // [THEN] keyColumns contains systemId
+        EntityContent.Get('keyColumns', Token);
+        KeyColumns := Token.AsArray();
+        KeyColumns.Get(0, Token);
+        LibraryAssert.AreEqual('systemId', Token.AsValue().AsText(), 'First key column should be systemId');
+    end;
+
+    [Test]
+    procedure TestCreateEntityContent_OpenMirroring_PKMirroringUsesPrimaryKey()
+    var
+        ADLSESetup: Record "ADLSE Setup";
+        ADLSETable: Record "ADLSE Table";
+        ADLSECDMUtil: Codeunit "ADLSE CDM Util";
+        EntityContent: JsonObject;
+        Token: JsonToken;
+        KeyColumns: JsonArray;
+        JsonText: Text;
+        HasPKField: Boolean;
+        i: Integer;
+    begin
+        // [SCENARIO] Open Mirroring CreateEntityContent uses Primary Key fields when PK mirroring is enabled
+        // [GIVEN] Open Mirroring setup with PK mirroring enabled
+        Initialize();
+        ADLSELibrarybc2adls.CleanUp();
+        ADLSELibrarybc2adls.CreateAdlseSetup("Storage Type"::"Open Mirroring");
+
+        ADLSESetup.GetSingleton();
+        ADLSESetup."Use Primary Key for Mirroring" := true;
+        ADLSESetup.Modify();
+
+        ADLSETable.Add(Database::"Reason Code");
+        ADLSELibrarybc2adls.InsertFields();
+        ADLSELibrarybc2adls.EnableFields();
+
+        // [WHEN] CreateEntityContent is called (Open Mirroring overload)
+        EntityContent := ADLSECDMUtil.CreateEntityContent(Database::"Reason Code");
+
+        // [THEN] keyColumns contains the primary key field (Code), not systemId
+        EntityContent.Get('keyColumns', Token);
+        KeyColumns := Token.AsArray();
+        EntityContent.WriteTo(JsonText);
+
+        // Verify systemId is NOT in keyColumns
+        HasPKField := false;
+        for i := 0 to KeyColumns.Count() - 1 do begin
+            KeyColumns.Get(i, Token);
+            LibraryAssert.AreNotEqual('systemId', Token.AsValue().AsText(), 'systemId should not be in keyColumns when PK mirroring is enabled');
+            if Token.AsValue().AsText() = 'Code' then
+                HasPKField := true;
+        end;
+        LibraryAssert.IsTrue(HasPKField, 'Primary key field Code should be in keyColumns');
+    end;
+
+    [Test]
+    procedure TestCreateEntityContent_OpenMirroring_PKMirroringIncludesCompanyForPerCompanyTable()
+    var
+        ADLSESetup: Record "ADLSE Setup";
+        ADLSETable: Record "ADLSE Table";
+        ADLSECDMUtil: Codeunit "ADLSE CDM Util";
+        EntityContent: JsonObject;
+        Token: JsonToken;
+        KeyColumns: JsonArray;
+        JsonText: Text;
+        HasCompanyField: Boolean;
+        i: Integer;
+    begin
+        // [SCENARIO] Open Mirroring with PK mirroring includes $Company for per-company tables
+        // [GIVEN] Open Mirroring setup with PK mirroring enabled, using a per-company table
+        Initialize();
+        ADLSELibrarybc2adls.CleanUp();
+        ADLSELibrarybc2adls.CreateAdlseSetup("Storage Type"::"Open Mirroring");
+
+        ADLSESetup.GetSingleton();
+        ADLSESetup."Use Primary Key for Mirroring" := true;
+        ADLSESetup.Modify();
+
+        ADLSETable.Add(Database::"G/L Entry");
+        ADLSELibrarybc2adls.InsertFields();
+        ADLSELibrarybc2adls.EnableFields();
+
+        // [WHEN] CreateEntityContent is called for a per-company table
+        EntityContent := ADLSECDMUtil.CreateEntityContent(Database::"G/L Entry");
+
+        // [THEN] keyColumns includes $Company
+        EntityContent.Get('keyColumns', Token);
+        KeyColumns := Token.AsArray();
+        EntityContent.WriteTo(JsonText);
+
+        HasCompanyField := false;
+        for i := 0 to KeyColumns.Count() - 1 do begin
+            KeyColumns.Get(i, Token);
+            if Token.AsValue().AsText() = '$Company' then
+                HasCompanyField := true;
+        end;
+        LibraryAssert.IsTrue(HasCompanyField, '$Company should be in keyColumns for per-company tables');
+    end;
+
     local procedure Initialize()
     var
         LibraryTestInitialize: Codeunit "Library - Test Initialize";

--- a/businessCentral/test/src/CDMUtilTests.Codeunit.al
+++ b/businessCentral/test/src/CDMUtilTests.Codeunit.al
@@ -407,9 +407,13 @@ codeunit 85569 "ADLSE CDM Util Tests"
     var
         ADLSETable: Record "ADLSE Table";
         ADLSECDMUtil: Codeunit "ADLSE CDM Util";
+        ADLSEUtil: Codeunit "ADLSE Util";
+        RecordRef: RecordRef;
+        SystemIdFieldRef: FieldRef;
         EntityContent: JsonObject;
         Token: JsonToken;
         KeyColumns: JsonArray;
+        ExpectedFieldName: Text;
     begin
         // [SCENARIO] Open Mirroring CreateEntityContent uses SystemId as keyColumn by default
         // [GIVEN] Open Mirroring setup without PK mirroring enabled
@@ -420,6 +424,12 @@ codeunit 85569 "ADLSE CDM Util Tests"
         ADLSELibrarybc2adls.InsertFields();
         ADLSELibrarybc2adls.EnableFields();
 
+        // Get the expected compliant field name for SystemId
+        RecordRef.Open(Database::"Reason Code");
+        SystemIdFieldRef := RecordRef.Field(RecordRef.SystemIdNo());
+        ExpectedFieldName := ADLSEUtil.GetDataLakeCompliantFieldName(SystemIdFieldRef);
+        RecordRef.Close();
+
         // [WHEN] CreateEntityContent is called (Open Mirroring overload)
         EntityContent := ADLSECDMUtil.CreateEntityContent(Database::"Reason Code");
 
@@ -427,7 +437,7 @@ codeunit 85569 "ADLSE CDM Util Tests"
         EntityContent.Get('keyColumns', Token);
         KeyColumns := Token.AsArray();
         KeyColumns.Get(0, Token);
-        LibraryAssert.AreEqual('systemId', Token.AsValue().AsText(), 'First key column should be systemId');
+        LibraryAssert.AreEqual(ExpectedFieldName, Token.AsValue().AsText(), 'First key column should be systemId');
     end;
 
     [Test]
@@ -436,9 +446,15 @@ codeunit 85569 "ADLSE CDM Util Tests"
         ADLSESetup: Record "ADLSE Setup";
         ADLSETable: Record "ADLSE Table";
         ADLSECDMUtil: Codeunit "ADLSE CDM Util";
+        ADLSEUtil: Codeunit "ADLSE Util";
+        RecordRef: RecordRef;
+        KeyRef: KeyRef;
+        SystemIdFieldRef: FieldRef;
         EntityContent: JsonObject;
         Token: JsonToken;
         KeyColumns: JsonArray;
+        ExpectedPKFieldName: Text;
+        SystemIdFieldName: Text;
         HasPKField: Boolean;
         i: Integer;
     begin
@@ -456,22 +472,29 @@ codeunit 85569 "ADLSE CDM Util Tests"
         ADLSELibrarybc2adls.InsertFields();
         ADLSELibrarybc2adls.EnableFields();
 
+        // Get expected compliant field names
+        RecordRef.Open(Database::"Reason Code");
+        KeyRef := RecordRef.KeyIndex(1);
+        ExpectedPKFieldName := ADLSEUtil.GetDataLakeCompliantFieldName(KeyRef.FieldIndex(1));
+        SystemIdFieldRef := RecordRef.Field(RecordRef.SystemIdNo());
+        SystemIdFieldName := ADLSEUtil.GetDataLakeCompliantFieldName(SystemIdFieldRef);
+        RecordRef.Close();
+
         // [WHEN] CreateEntityContent is called (Open Mirroring overload)
         EntityContent := ADLSECDMUtil.CreateEntityContent(Database::"Reason Code");
 
-        // [THEN] keyColumns contains the primary key field (Code), not systemId
+        // [THEN] keyColumns contains the primary key field, not systemId
         EntityContent.Get('keyColumns', Token);
         KeyColumns := Token.AsArray();
 
-        // Verify systemId is NOT in keyColumns
         HasPKField := false;
         for i := 0 to KeyColumns.Count() - 1 do begin
             KeyColumns.Get(i, Token);
-            LibraryAssert.AreNotEqual('systemId', Token.AsValue().AsText(), 'systemId should not be in keyColumns when PK mirroring is enabled');
-            if Token.AsValue().AsText() = 'Code' then
+            LibraryAssert.AreNotEqual(SystemIdFieldName, Token.AsValue().AsText(), 'systemId should not be in keyColumns when PK mirroring is enabled');
+            if Token.AsValue().AsText() = ExpectedPKFieldName then
                 HasPKField := true;
         end;
-        LibraryAssert.IsTrue(HasPKField, 'Primary key field Code should be in keyColumns');
+        LibraryAssert.IsTrue(HasPKField, 'Primary key field should be in keyColumns');
     end;
 
     [Test]

--- a/businessCentral/test/src/CDMUtilTests.Codeunit.al
+++ b/businessCentral/test/src/CDMUtilTests.Codeunit.al
@@ -410,7 +410,6 @@ codeunit 85569 "ADLSE CDM Util Tests"
         EntityContent: JsonObject;
         Token: JsonToken;
         KeyColumns: JsonArray;
-        JsonText: Text;
     begin
         // [SCENARIO] Open Mirroring CreateEntityContent uses SystemId as keyColumn by default
         // [GIVEN] Open Mirroring setup without PK mirroring enabled
@@ -440,7 +439,6 @@ codeunit 85569 "ADLSE CDM Util Tests"
         EntityContent: JsonObject;
         Token: JsonToken;
         KeyColumns: JsonArray;
-        JsonText: Text;
         HasPKField: Boolean;
         i: Integer;
     begin
@@ -464,7 +462,6 @@ codeunit 85569 "ADLSE CDM Util Tests"
         // [THEN] keyColumns contains the primary key field (Code), not systemId
         EntityContent.Get('keyColumns', Token);
         KeyColumns := Token.AsArray();
-        EntityContent.WriteTo(JsonText);
 
         // Verify systemId is NOT in keyColumns
         HasPKField := false;
@@ -486,7 +483,6 @@ codeunit 85569 "ADLSE CDM Util Tests"
         EntityContent: JsonObject;
         Token: JsonToken;
         KeyColumns: JsonArray;
-        JsonText: Text;
         HasCompanyField: Boolean;
         i: Integer;
     begin
@@ -510,7 +506,6 @@ codeunit 85569 "ADLSE CDM Util Tests"
         // [THEN] keyColumns includes $Company
         EntityContent.Get('keyColumns', Token);
         KeyColumns := Token.AsArray();
-        EntityContent.WriteTo(JsonText);
 
         HasCompanyField := false;
         for i := 0 to KeyColumns.Count() - 1 do begin

--- a/businessCentral/test/src/DeleteTests.Codeunit.al
+++ b/businessCentral/test/src/DeleteTests.Codeunit.al
@@ -120,6 +120,61 @@ codeunit 85563 "ADLSE Delete Tests"
         LibraryAssert.TableIsEmpty(Database::"ADLSE Deleted Record");
     end;
 
+    [Test]
+    procedure DeleteARecordWithPKMirroringStoresPrimaryKeyValues()
+    var
+        ADLSESetup: Record "ADLSE Setup";
+        PaymentTerms: Record "Payment Terms";
+        ADLSEDeletedRecord: Record "ADLSE Deleted Record";
+        ADLSEUtil: Codeunit "ADLSE Util";
+        RecordRef: RecordRef;
+        PKFieldRef: FieldRef;
+        PaymentTermGuid: Guid;
+        PKValues: JsonObject;
+        Token: JsonToken;
+    begin
+        // [SCENARIO] When PK mirroring is enabled, deleting a record stores Primary Key Values
+        // and CreateFakeRecordForDeletedAction restores them on the fake record
+        // [GIVEN] Open Mirroring setup with PK mirroring enabled
+        Initialize();
+        ADLSELibrarybc2adls.CleanUp();
+        ADLSELibrarybc2adls.CreateAdlseSetup("Storage Type"::"Open Mirroring");
+
+        ADLSESetup.GetSingleton();
+        ADLSESetup."Use Primary Key for Mirroring" := true;
+        ADLSESetup.Modify();
+
+        // [GIVEN] Insert a record and set up export
+        InsertPaymentTerms(PaymentTerms);
+        ADLSETable.Add(PaymentTerms.RecordId.TableNo);
+        ADLSELibrarybc2adls.InsertFields();
+        ADLSELibrarybc2adls.EnableField(PaymentTerms.RecordId.TableNo, PaymentTerms.FieldNo(Code));
+        ADLSELibrarybc2adls.EnableField(PaymentTerms.RecordId.TableNo, PaymentTerms.FieldNo(Description));
+        ADLSELibrarybc2adls.MockCreateExport(PaymentTerms.RecordId.TableNo);
+
+        // [WHEN] a record is deleted
+        DeletePaymentTerms(PaymentTerms, PaymentTermGuid);
+
+        // [THEN] ADLSE Deleted Record has Primary Key Values populated
+        ADLSEDeletedRecord.Reset();
+        ADLSEDeletedRecord.SetRange("Table ID", Database::"Payment Terms");
+        ADLSEDeletedRecord.FindFirst();
+        LibraryAssert.AreNotEqual('', ADLSEDeletedRecord."Primary Key Values", 'Primary Key Values should be populated');
+
+        // [THEN] Primary Key Values JSON contains the Code field value
+        PKValues.ReadFrom(ADLSEDeletedRecord."Primary Key Values");
+        PKValues.Get(Format(PaymentTerms.FieldNo(Code)), Token);
+        LibraryAssert.AreEqual(PaymentTerms.Code, Token.AsValue().AsText(), 'PK value should match the deleted record Code');
+
+        // [THEN] CreateFakeRecordForDeletedAction restores PK fields on the fake record
+        RecordRef.Open(Database::"Payment Terms");
+        RecordRef.Init();
+        ADLSEUtil.CreateFakeRecordForDeletedAction(ADLSEDeletedRecord, RecordRef);
+        PKFieldRef := RecordRef.Field(PaymentTerms.FieldNo(Code));
+        LibraryAssert.AreEqual(PaymentTerms.Code, Format(PKFieldRef.Value()), 'Fake record should have PK Code field restored');
+        RecordRef.Close();
+    end;
+
     local procedure InsertPaymentTerms(var PaymentTerms: Record "Payment Terms")
     begin
         PaymentTerms.Init();

--- a/businessCentral/test/src/DeleteTests.Codeunit.al
+++ b/businessCentral/test/src/DeleteTests.Codeunit.al
@@ -124,6 +124,7 @@ codeunit 85563 "ADLSE Delete Tests"
     procedure DeleteARecordWithPKMirroringStoresPrimaryKeyValues()
     var
         ADLSESetup: Record "ADLSE Setup";
+        ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         PaymentTerms: Record "Payment Terms";
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
         ADLSEUtil: Codeunit "ADLSE Util";
@@ -151,6 +152,13 @@ codeunit 85563 "ADLSE Delete Tests"
         ADLSELibrarybc2adls.EnableField(PaymentTerms.RecordId.TableNo, PaymentTerms.FieldNo(Code));
         ADLSELibrarybc2adls.EnableField(PaymentTerms.RecordId.TableNo, PaymentTerms.FieldNo(Description));
         ADLSELibrarybc2adls.MockCreateExport(PaymentTerms.RecordId.TableNo);
+
+        // [GIVEN] Create timestamp record so delete tracking knows the table is tracked
+        ADLSETableLastTimestamp.Init();
+        ADLSETableLastTimestamp."Company Name" := CopyStr(CompanyName(), 1, 30);
+        ADLSETableLastTimestamp."Table ID" := PaymentTerms.RecordId.TableNo;
+        if not ADLSETableLastTimestamp.Find() then
+            ADLSETableLastTimestamp.Insert();
 
         // [WHEN] a record is deleted
         DeletePaymentTerms(PaymentTerms, PaymentTermGuid);

--- a/businessCentral/test/src/Librarybc2adls.Codeunit.al
+++ b/businessCentral/test/src/Librarybc2adls.Codeunit.al
@@ -19,6 +19,9 @@ codeunit 85561 "ADLSE Library - bc2adls"
             ADLSESetup."Storage Type" := "Storage Type"::"Azure Data Lake";
             ADLSESetup.Container := 'bc2adls';
             ADLSESetup."Account Name" := 'bc2adls';
+        end else if "Storage Type" = "Storage Type"::"Open Mirroring" then begin
+            ADLSESetup."Storage Type" := "Storage Type"::"Open Mirroring";
+            ADLSESetup.LandingZone := 'https://bc2adls.fabric.microsoft.com';
         end else begin
             ADLSESetup."Storage Type" := "Storage Type"::"Microsoft Fabric";
             ADLSESetup.Workspace := 'bc2adls';


### PR DESCRIPTION
## Summary

Adds a global **"Use Primary Key for Mirroring"** setting that uses BC table primary key fields as `keyColumns` in Open Mirroring metadata instead of the default `SystemId + $Company`. This prevents duplicate records when BC recreates records with new SystemIds (e.g., by integrations or customizations).

Resolves #456

## Changes

### Setup
- **`Setup.Table.al`**: New boolean field `"Use Primary Key for Mirroring"` (field 85) with schema-change validation
- **`Setup.Page.al`**: Field shown in Export Settings, visible only for Open Mirroring storage type

### Metadata Generation
- **`CDMUtil.Codeunit.al`**: When enabled, `CreateEntityContent(TableID)` builds `keyColumns` from the table's primary key fields (via `IsPartOfPrimaryKey`) instead of SystemId. `$Company` is still automatically included for per-company tables. `IsNullable` is correctly set based on whether fields are part of the PK.

### Delete Tracking
- **`DeletedRecord.Table.al`**: New `"Primary Key Values"` field (Text[2048]) stores PK field values as JSON at deletion time
- **`Util.Codeunit.al`**: `CreateFakeRecordForDeletedAction` now populates PK fields on the fake RecordRef from stored JSON, with type-safe conversion via `SetFieldRefValueFromText`

### Tests
- **`CDMUtilTests.Codeunit.al`**: 3 new tests covering default SystemId behavior, PK-based keyColumns, and `$Company` inclusion for per-company tables
- **`Librarybc2adls.Codeunit.al`**: Updated `CreateAdlseSetup` to support Open Mirroring storage type

## Behavior
- **Default (off)**: No change — `SystemId + $Company` continues to be used as keyColumns
- **When enabled**: All tables use their BC Primary Key fields as keyColumns in Open Mirroring metadata
- Delete tracking stores PK values at deletion time so Fabric can identify the correct row to delete