### PR TITLE
Add OnAfterStartExport event and refactor access modifiers

### DIFF
--- a/businessCentral/app/src/Execution.Codeunit.al
+++ b/businessCentral/app/src/Execution.Codeunit.al
@@ -84,6 +84,8 @@ codeunit 82569 "ADLSE Execution"
         Message(ExportStartedTxt, Started, Counter);
         if EmitTelemetry then
             Log('ADLSE-001', StrSubstNo(ExportStartedTxt, Started, Counter), Verbosity::Normal);
+
+        OnAfterStartExport(AdlseTable);
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Setup", 'r')]
@@ -294,5 +296,10 @@ codeunit 82569 "ADLSE Execution"
     local procedure OnBeforeScheduleExport(var Handled: Boolean)
     begin
 
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterStartExport(var ADLSETable: Record "ADLSE Table")
+    begin
     end;
 }

--- a/businessCentral/app/src/SessionManager.Codeunit.al
+++ b/businessCentral/app/src/SessionManager.Codeunit.al
@@ -70,6 +70,8 @@ codeunit 82570 "ADLSE Session Manager"
                 ADLSEExecution.Log('ADLSE-024', 'No changes to be exported.', Verbosity::Normal, CustomDimensions);
             end;
         end;
+
+        OnAfterStartExport(TableID, ExportWasPending, ForceExport, EmitTelemetry, Started);
     end;
 
     local procedure DataChangesExist(TableID: Integer): Boolean
@@ -192,5 +194,10 @@ codeunit 82570 "ADLSE Session Manager"
         if IsolatedStorage.Set(PendingTablesKeyTxt, Value, DataScope::Company) then
             Commit(); // changing isolated storage triggers a write transaction      
 #pragma warning restore LC0043      
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterStartExport(TableID: Integer; ExportWasPending: Boolean; ForceExport: Boolean; EmitTelemetry: Boolean; var Started: Boolean)
+    begin
     end;
 }

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -7,7 +7,6 @@ using System.Reflection;
 table 82561 "ADLSE Table"
 #pragma warning restore
 {
-    Access = Internal;
     Caption = 'ADLSE Table';
     DataClassification = CustomerContent;
     DataPerCompany = false;
@@ -16,18 +15,20 @@ table 82561 "ADLSE Table"
                   tabledata "ADLSE Deleted Record" = d;
 
     fields
-    {
+    {        
         field(1; "Table ID"; Integer)
         {
             AllowInCustomizations = AsReadOnly;
             Editable = false;
             Caption = 'Table ID';
+            Access = Internal;
         }
         field(3; Enabled; Boolean)
         {
             Editable = false;
             Caption = 'Enabled';
             ToolTip = 'Specifies the state of the table. Set this checkmark to export this table, otherwise not.';
+            Access = Internal;
 
             trigger OnValidate()
             var
@@ -49,6 +50,7 @@ table 82561 "ADLSE Table"
             TableRelation = "ADLSE Export Category Table";
             DataClassification = CustomerContent;
             ToolTip = 'Specifies the Export Category which can be linked to tables which are part of the export to Azure Datalake. The Category can be used to schedule the export.';
+            Access = Internal;
         }
         field(15; ExportFileNumber; Integer)
         {
@@ -56,11 +58,13 @@ table 82561 "ADLSE Table"
             AllowInCustomizations = AsReadOnly;
             ObsoleteState = Pending;
             ObsoleteReason = 'Open Mirroring now uses GUIDs for file names instead of sequential numbering.';
+            Access = Internal;
         }
         field(17; "Initial Load Start Date"; Date)
         {
             Caption = 'Initial Load Start Date';
             ToolTip = 'Specifies the starting date for the initial data load. Only records with SystemModifiedAt >= this date will be exported on the first export. Leave blank to export all historical data.';
+            Access = Internal;
         }
         field(16; "Process Type"; Enum "ADLSE Process Type")
         {
@@ -69,6 +73,7 @@ table 82561 "ADLSE Table"
             ObsoleteState = Removed;
             ObsoleteReason = 'This field will be removed in a future release because readuncommitted will be the default behavior because of performance.';
             ToolTip = 'Specifies how this table should be processed during export. Standard uses normal processing, Ignore Read Isolation disables read isolation for performance, and Commit Externally uses external commit for large tables.';
+            Access = Internal;
         }
     }
 
@@ -149,7 +154,7 @@ table 82561 "ADLSE Table"
         InvalidFieldConfiguredMsg: Label 'The following fields have been incorrectly enabled for exports in the table %1: %2', Comment = '%1 = table name; %2 = List of invalid field names';
         WarnOfSchemaChangeQst: Label 'Data may have been exported from this table before. Changing the export schema now may cause unexpected side- effects. You may reset the table first so all the data shall be exported afresh. Do you still wish to continue?';
 
-    procedure FieldsChosen(): Integer
+    internal procedure FieldsChosen(): Integer
     var
         ADLSEField: Record "ADLSE Field";
     begin
@@ -159,7 +164,7 @@ table 82561 "ADLSE Table"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'i')]
-    procedure Add(TableID: Integer)
+    internal procedure Add(TableID: Integer)
     var
         ADLSEExternalEvents: Codeunit "ADLSE External Events";
     begin
@@ -198,7 +203,7 @@ table 82561 "ADLSE Table"
             Error(TableNotNormalErr, TableCaption);
     end;
 
-    procedure CheckNotExporting()
+    internal procedure CheckNotExporting()
     var
         ADLSEUtil: Codeunit "ADLSE Util";
     begin
@@ -218,13 +223,13 @@ table 82561 "ADLSE Table"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'rm')]
-    procedure ResetSelected()
+    internal procedure ResetSelected()
     begin
         ResetSelected(false);
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'rm')]
-    procedure ResetSelected(AllCompanies: Boolean)
+    internal procedure ResetSelected(AllCompanies: Boolean)
     var
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
@@ -295,7 +300,7 @@ table 82561 "ADLSE Table"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'r')]
-    procedure ListInvalidFieldsBeingExported() FieldList: List of [Text]
+    internal procedure ListInvalidFieldsBeingExported() FieldList: List of [Text]
     var
         ADLSEField: Record "ADLSE Field";
         ADLSESetup: Codeunit "ADLSE Setup";
@@ -323,7 +328,7 @@ table 82561 "ADLSE Table"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'rm')]
-    procedure AddAllFields()
+    internal procedure AddAllFields()
     var
         ADLSEFields: Record "ADLSE Field";
     begin
@@ -338,7 +343,7 @@ table 82561 "ADLSE Table"
             until ADLSEFields.Next() = 0;
     end;
 
-    procedure GetLastHeartbeat(): DateTime
+    internal procedure GetLastHeartbeat(): DateTime
     var
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
     begin
@@ -348,7 +353,7 @@ table 82561 "ADLSE Table"
         exit(ADLSETableLastTimestamp.SystemModifiedAt)
     end;
 
-    procedure GetActiveSessionId(): Integer
+    internal procedure GetActiveSessionId(): Integer
     var
         ExpSessionId: Integer;
     begin
@@ -359,7 +364,7 @@ table 82561 "ADLSE Table"
             exit(ExpSessionId);
     end;
 
-    procedure GetCurrentSessionId(): Integer
+    internal procedure GetCurrentSessionId(): Integer
     var
         CurrentSession: Record "ADLSE Current Session";
     begin
@@ -369,7 +374,7 @@ table 82561 "ADLSE Table"
         exit(0);
     end;
 
-    procedure StopActiveSession()
+    internal procedure StopActiveSession()
     var
         CurrentSession: Record "ADLSE Current Session";
         Run: Record "ADLSE Run";
@@ -440,7 +445,7 @@ table 82561 "ADLSE Table"
         end;
     end;
 
-    procedure DoChooseFields()
+    internal procedure DoChooseFields()
     var
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         ADLSESetup: Codeunit "ADLSE Setup";
@@ -451,7 +456,7 @@ table 82561 "ADLSE Table"
         ADLSESetup.ChooseFieldsToExport(Rec);
     end;
 
-    procedure IssueNotificationIfInvalidFieldsConfiguredToBeExported()
+    internal procedure IssueNotificationIfInvalidFieldsConfiguredToBeExported()
     var
         ADLSEUtil: Codeunit "ADLSE Util";
         InvalidFieldNotification: Notification;


### PR DESCRIPTION
This pull request introduces new integration events to allow for custom logic after export operations and makes several access-level adjustments to the `ADLSE Table` table and its fields and methods, enhancing extensibility and encapsulation.

**Integration event additions:**

* Added `OnAfterStartExport` integration events to both `codeunit 82569 "ADLSE Execution"` and `codeunit 82570 "ADLSE Session Manager"` to enable subscribers to execute custom logic after the export process starts. [[1]](diffhunk://#diff-c7245cee389f84f6b45a5ae0ee69010dcde6b2b9ed7f8173a221b0c9a4bd7794R87-R88) [[2]](diffhunk://#diff-c7245cee389f84f6b45a5ae0ee69010dcde6b2b9ed7f8173a221b0c9a4bd7794R300-R304) [[3]](diffhunk://#diff-0e799548390ae1c72cdb2a9e9e7953a14ceb21b3add01d1642a2c18f5f3da207R73-R74) [[4]](diffhunk://#diff-0e799548390ae1c72cdb2a9e9e7953a14ceb21b3add01d1642a2c18f5f3da207R198-R202)

**Access-level and encapsulation improvements in `ADLSE Table`:**

* Set `Access = Internal` for several fields in the `ADLSE Table` to restrict their visibility to within the extension. [[1]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51R24-R31) [[2]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51R53-R67) [[3]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51R76)
* Changed multiple procedures in `ADLSE Table` to `internal` scope, limiting their usage to within the extension and improving encapsulation. [[1]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L152-R157) [[2]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L162-R167) [[3]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L201-R206) [[4]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L221-R232) [[5]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L298-R303) [[6]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L326-R331) [[7]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L341-R346) [[8]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L351-R356) [[9]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L362-R367) [[10]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L372-R377) [[11]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L443-R448) [[12]](diffhunk://#diff-304a6673a0c0ee702a4df09db962a4ce6c530fceebe0d23ce2679a31d3265a51L454-R459)
* Removed the table-level `Access = Internal;` property from the `ADLSE Table` definition and instead set it on individual fields.