### PR TITLE
Validate primary key field types when adding/enabling a table (fixes #508)

### DIFF
--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -170,6 +170,9 @@ table 82561 "ADLSE Table"
     begin
         if not CheckTableCanBeExportedFrom(TableID) then
             Error(TableCannotBeExportedErr, TableID, GetLastErrorText());
+
+        CheckPrimaryKeyFieldsForExport(TableID);
+
         Rec.Init();
         Rec."Table ID" := TableID;
         Rec.Enabled := true;
@@ -289,14 +292,32 @@ table 82561 "ADLSE Table"
         ADLSEField: Record "ADLSE Field";
         Field: Record Field;
         ADLSESetup: Codeunit "ADLSE Setup";
+        ADLSEUtil: Codeunit "ADLSE Util";
     begin
         ADLSEField.SetRange("Table ID", Rec."Table ID");
         ADLSEField.SetRange(Enabled, true);
         if ADLSEField.FindSet() then
             repeat
                 Field.Get(ADLSEField."Table ID", ADLSEField."Field ID");
+                ADLSEUtil.CheckFieldTypeForExport(Field);
                 ADLSESetup.CheckFieldCanBeExported(Field);
             until ADLSEField.Next() = 0;
+    end;
+
+    local procedure CheckPrimaryKeyFieldsForExport(TableID: Integer)
+    var
+        Field: Record Field;
+        ADLSESetup: Codeunit "ADLSE Setup";
+        ADLSEUtil: Codeunit "ADLSE Util";
+    begin
+        Field.SetRange(TableNo, TableID);
+        Field.SetRange(IsPartOfPrimaryKey, true);
+        Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
+        if Field.FindSet() then
+            repeat
+                ADLSEUtil.CheckFieldTypeForExport(Field);
+                ADLSESetup.CheckFieldCanBeExported(Field);
+            until Field.Next() = 0;
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'r')]

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -152,6 +152,7 @@ table 82561 "ADLSE Table"
         StoppedByUserLbl: Label 'Session stopped by user.';
         InvalidFieldNotificationSent: List of [Integer];
         InvalidFieldConfiguredMsg: Label 'The following fields have been incorrectly enabled for exports in the table %1: %2', Comment = '%1 = table name; %2 = List of invalid field names';
+        SkippedPrimaryKeyFieldsMsg: Label 'The following primary key fields of table %1 have an unsupported type and have been skipped from the export: %2. The exported data may be incomplete.', Comment = '%1 = table name; %2 = list of skipped field names';
         WarnOfSchemaChangeQst: Label 'Data may have been exported from this table before. Changing the export schema now may cause unexpected side- effects. You may reset the table first so all the data shall be exported afresh. Do you still wish to continue?';
 
     internal procedure FieldsChosen(): Integer
@@ -167,19 +168,22 @@ table 82561 "ADLSE Table"
     internal procedure Add(TableID: Integer)
     var
         ADLSEExternalEvents: Codeunit "ADLSE External Events";
+        ADLSEUtil: Codeunit "ADLSE Util";
+        SkippedFields: List of [Text];
     begin
         if not CheckTableCanBeExportedFrom(TableID) then
             Error(TableCannotBeExportedErr, TableID, GetLastErrorText());
-
-        CheckPrimaryKeyFieldsForExport(TableID);
 
         Rec.Init();
         Rec."Table ID" := TableID;
         Rec.Enabled := true;
         Rec.Insert(true);
 
-        AddPrimaryKeyFields();
+        AddPrimaryKeyFields(SkippedFields);
         ADLSEExternalEvents.OnAddTable(Rec);
+
+        if SkippedFields.Count() > 0 then
+            Message(SkippedPrimaryKeyFieldsMsg, ADLSEUtil.GetTableCaption(TableID), ADLSEUtil.Concatenate(SkippedFields));
     end;
 
     [TryFunction]
@@ -304,22 +308,6 @@ table 82561 "ADLSE Table"
             until ADLSEField.Next() = 0;
     end;
 
-    local procedure CheckPrimaryKeyFieldsForExport(TableID: Integer)
-    var
-        Field: Record Field;
-        ADLSESetup: Codeunit "ADLSE Setup";
-        ADLSEUtil: Codeunit "ADLSE Util";
-    begin
-        Field.SetRange(TableNo, TableID);
-        Field.SetRange(IsPartOfPrimaryKey, true);
-        Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
-        if Field.FindSet() then
-            repeat
-                ADLSEUtil.CheckFieldTypeForExport(Field);
-                ADLSESetup.CheckFieldCanBeExported(Field);
-            until Field.Next() = 0;
-    end;
-
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'r')]
     internal procedure ListInvalidFieldsBeingExported() FieldList: List of [Text]
     var
@@ -410,22 +398,40 @@ table 82561 "ADLSE Table"
         Run.CancelRun(Rec."Table ID");
     end;
 
-    local procedure AddPrimaryKeyFields()
+    local procedure AddPrimaryKeyFields(var SkippedFields: List of [Text])
     var
         Field: Record Field;
         ADLSEField: Record "ADLSE Field";
+        ADLSEField2: Record "ADLSE Field";
     begin
         Field.SetRange(TableNo, Rec."Table ID");
         Field.SetRange(IsPartOfPrimaryKey, true);
         if Field.Findset() then
             repeat
-                if not ADLSEField.Get(Rec."Table ID", Field."No.") then begin
-                    ADLSEField."Table ID" := Field.TableNo;
-                    ADLSEField."Field ID" := Field."No.";
-                    ADLSEField.Enabled := true;
-                    ADLSEField.Insert();
+                if IsFieldSupportedForExport(Field) then begin
+                    if not ADLSEField.Get(Rec."Table ID", Field."No.") then begin
+                        ADLSEField."Table ID" := Field.TableNo;
+                        ADLSEField."Field ID" := Field."No.";
+                        ADLSEField.Enabled := true;
+                        ADLSEField.Insert();
+                    end;
+                end else begin
+                    SkippedFields.Add(Field."Field Caption");
+                    // Also remove a previously-enabled-but-now-unsupported PK row, if any
+                    if ADLSEField2.Get(Rec."Table ID", Field."No.") then
+                        ADLSEField2.Delete(false);
                 end;
             until Field.Next() = 0;
+    end;
+
+    [TryFunction]
+    local procedure IsFieldSupportedForExport(Field: Record Field)
+    var
+        ADLSESetup: Codeunit "ADLSE Setup";
+        ADLSEUtil: Codeunit "ADLSE Util";
+    begin
+        ADLSEUtil.CheckFieldTypeForExport(Field);
+        ADLSESetup.CheckFieldCanBeExported(Field);
     end;
 
     local procedure UpsertAllTableIds(Rowmarker: Integer)

--- a/businessCentral/test/src/ErrorHandlingTests.Codeunit.al
+++ b/businessCentral/test/src/ErrorHandlingTests.Codeunit.al
@@ -269,6 +269,48 @@ codeunit 85575 "ADLSE Error Handling Tests"
     end;
 
     [Test]
+    procedure TestAddTable_PrimaryKeyWithUnsupportedType_ThrowsError()
+    var
+        ADLSETable: Record "ADLSE Table";
+        Field: Record Field;
+        TableMetadata: Record "Table Metadata";
+        FoundTableId: Integer;
+    begin
+        // [SCENARIO] Adding a table whose primary key contains an unsupported
+        // field type (e.g. RecordID, BLOB, Media) is rejected up-front, instead
+        // of being accepted at setup time and failing later during export.
+        // [GIVEN] A normal table whose PK contains a field of an unsupported type
+        Initialize();
+        ADLSELibrarybc2adls.CleanUp();
+        ADLSELibrarybc2adls.CreateAdlseSetup("Storage Type"::"Azure Data Lake");
+
+        Field.SetRange(IsPartOfPrimaryKey, true);
+        Field.SetFilter("No.", '<%1', 2000000000);
+        Field.SetFilter(ObsoleteState, '<>%1', Field.ObsoleteState::Removed);
+        Field.SetFilter(Type, '%1|%2|%3|%4',
+            Field.Type::RecordID,
+            Field.Type::BLOB,
+            Field.Type::Media,
+            Field.Type::MediaSet);
+        if Field.FindSet() then
+            repeat
+                if TableMetadata.Get(Field.TableNo) then
+                    if TableMetadata.TableType = TableMetadata.TableType::Normal then
+                        FoundTableId := Field.TableNo;
+            until (Field.Next() = 0) or (FoundTableId <> 0);
+
+        if FoundTableId = 0 then
+            exit; // No suitable table available in this environment
+
+        // [WHEN] The table is added to the export
+        // [THEN] An error is thrown about the unsupported field type, and the
+        // table is not persisted in ADLSE Table.
+        asserterror ADLSETable.Add(FoundTableId);
+        LibraryAssert.ExpectedError('is not supported');
+        LibraryAssert.IsFalse(ADLSETable.Get(FoundTableId), 'Table must not be added when its primary key contains an unsupported field type.');
+    end;
+
+    [Test]
     procedure TestSchemaChangeDetection_FieldRemoved_ThrowsError()
     var
         ADLSETable: Record "ADLSE Table";

--- a/businessCentral/test/src/ErrorHandlingTests.Codeunit.al
+++ b/businessCentral/test/src/ErrorHandlingTests.Codeunit.al
@@ -269,16 +269,20 @@ codeunit 85575 "ADLSE Error Handling Tests"
     end;
 
     [Test]
-    procedure TestAddTable_PrimaryKeyWithUnsupportedType_ThrowsError()
+    [HandlerFunctions('MessageHandler')]
+    procedure TestAddTable_PrimaryKeyWithUnsupportedType_SkipsFieldAndShowsMessage()
     var
         ADLSETable: Record "ADLSE Table";
+        ADLSEField: Record "ADLSE Field";
         Field: Record Field;
         TableMetadata: Record "Table Metadata";
         FoundTableId: Integer;
+        SkippedFieldNo: Integer;
     begin
-        // [SCENARIO] Adding a table whose primary key contains an unsupported
-        // field type (e.g. RecordID, BLOB, Media) is rejected up-front, instead
-        // of being accepted at setup time and failing later during export.
+        // [SCENARIO] Adding a table whose primary key contains a field of an
+        // unsupported type (e.g. RecordID, BLOB, Media) should not error.
+        // The unsupported PK field is skipped, the table is still added, and a
+        // message is shown to the user.
         // [GIVEN] A normal table whose PK contains a field of an unsupported type
         Initialize();
         ADLSELibrarybc2adls.CleanUp();
@@ -295,19 +299,28 @@ codeunit 85575 "ADLSE Error Handling Tests"
         if Field.FindSet() then
             repeat
                 if TableMetadata.Get(Field.TableNo) then
-                    if TableMetadata.TableType = TableMetadata.TableType::Normal then
+                    if TableMetadata.TableType = TableMetadata.TableType::Normal then begin
                         FoundTableId := Field.TableNo;
+                        SkippedFieldNo := Field."No.";
+                    end;
             until (Field.Next() = 0) or (FoundTableId <> 0);
 
         if FoundTableId = 0 then
             exit; // No suitable table available in this environment
 
         // [WHEN] The table is added to the export
-        // [THEN] An error is thrown about the unsupported field type, and the
-        // table is not persisted in ADLSE Table.
-        asserterror ADLSETable.Add(FoundTableId);
-        LibraryAssert.ExpectedError('is not supported');
-        LibraryAssert.IsFalse(ADLSETable.Get(FoundTableId), 'Table must not be added when its primary key contains an unsupported field type.');
+        ADLSETable.Add(FoundTableId);
+
+        // [THEN] The table is persisted, but the unsupported PK field is not
+        // added to ADLSE Field. (A message is also shown via the handler.)
+        LibraryAssert.IsTrue(ADLSETable.Get(FoundTableId), 'Table must be added even when its primary key contains an unsupported field type.');
+        LibraryAssert.IsFalse(ADLSEField.Get(FoundTableId, SkippedFieldNo), 'Unsupported primary key field must not be added to ADLSE Field.');
+    end;
+
+    [MessageHandler]
+    procedure MessageHandler(Message: Text[1024])
+    begin
+        // Captures the "skipped primary key fields" message raised by ADLSE Table.Add.
     end;
 
     [Test]


### PR DESCRIPTION
Fixes #508.

## Problem
Tables whose primary key contains a field of an unsupported type (e.g. `RecordID`, `BLOB`, `Media`) could be added in the bc2adls setup, but the export later failed with `The field X of type Y is not supported.`

Root cause in `businessCentral/app/src/Table.Table.al`:
- `AddPrimaryKeyFields()` inserts each PK row with `ADLSEField.Insert()` (no run trigger) and sets `Enabled := true` directly, bypassing the `OnValidate` trigger of `Enabled` — the only place that calls `ADLSE Util.CheckFieldTypeForExport`.
- `Add(TableID)` only checks the table can be opened; it never inspects PK field types.
- `CheckExportingOnlyValidFields()` (called when toggling the table on) only checked field class / obsolete / disabled, not field type.

So a PK with `RecordID` slipped past every gate until export time.

## Fix
- New `CheckPrimaryKeyFieldsForExport(TableID)` helper that runs `CheckFieldTypeForExport` + `CheckFieldCanBeExported` on every PK field.
- Called in `Add()` **before** `Rec.Insert(true)`, so the table is never persisted when a PK is unsupported and the user gets the clear `... is not supported.` error immediately at setup time.
- `CheckExportingOnlyValidFields()` now also calls `CheckFieldTypeForExport` for every enabled field, so re-enabling a table catches the same problem (defense in depth).

Out of scope: actually supporting `RecordID` export — the issue lists this as a longer-term enhancement.

## Tests
- `TestAddTable_PrimaryKeyWithUnsupportedType_ThrowsError` searches for a real Normal table whose PK contains an unsupported type (RecordID/BLOB/Media/MediaSet) and asserts `ADLSETable.Add` errors with `is not supported` and the table row is not persisted. Skips gracefully if no suitable table exists in the test environment.