### PR TITLE
feat: certificate-based OAuth2 authentication (#513)

### DIFF
--- a/businessCentral/app/src/Credentials.Codeunit.al
+++ b/businessCentral/app/src/Credentials.Codeunit.al
@@ -122,7 +122,9 @@ codeunit 82565 "ADLSE Credentials"
     procedure SetClientCertificate(NewCertificateValue: Text): Text
     begin
         ClientCertificate := NewCertificateValue;
-        SetSecret(ClientCertificateKeyNameTok, NewCertificateValue);
+        // Certificates are too large for IsolatedStorage.SetEncrypted; store plain.
+        // The PFX is protected by its own password (stored encrypted separately).
+        SetPlain(ClientCertificateKeyNameTok, NewCertificateValue);
     end;
 
     [NonDebuggable]
@@ -163,6 +165,14 @@ codeunit 82565 "ADLSE Credentials"
             exit;
         end;
         IsolatedStorage.Set(KeyName, Secret, IsolatedStorageDataScope());
+#pragma warning restore LC0043
+    end;
+
+    [NonDebuggable]
+    local procedure SetPlain(KeyName: Text; Value: Text)
+    begin
+#pragma warning disable LC0043
+        IsolatedStorage.Set(KeyName, Value, IsolatedStorageDataScope());
 #pragma warning restore LC0043
     end;
 

--- a/businessCentral/app/src/Credentials.Codeunit.al
+++ b/businessCentral/app/src/Credentials.Codeunit.al
@@ -17,11 +17,19 @@ codeunit 82565 "ADLSE Credentials"
         [NonDebuggable]
         StorageTenantID: Text;
 
+        [NonDebuggable]
+        ClientCertificate: Text;
+
+        [NonDebuggable]
+        ClientCertificatePassword: Text;
+
         Initialized: Boolean;
         ValueNotFoundErr: Label 'No value found for %1.', Comment = '%1 = name of the key';
         TenantIdKeyNameTok: Label 'adlse-tenant-id', Locked = true;
         ClientIdKeyNameTok: Label 'adlse-client-id', Locked = true;
         ClientSecretKeyNameTok: Label 'adlse-client-secret', Locked = true;
+        ClientCertificateKeyNameTok: Label 'adlse-certificate', Locked = true;
+        ClientCertificatePasswordKeyNameTok: Label 'adlse-certificate-password', Locked = true;
 
     [NonDebuggable]
     procedure Init()
@@ -29,6 +37,8 @@ codeunit 82565 "ADLSE Credentials"
         StorageTenantID := GetSecret(TenantIdKeyNameTok);
         ClientID := GetSecret(ClientIdKeyNameTok);
         ClientSecret := GetSecret(ClientSecretKeyNameTok);
+        ClientCertificate := GetSecret(ClientCertificateKeyNameTok);
+        ClientCertificatePassword := GetSecret(ClientCertificatePasswordKeyNameTok);
         Initialized := true;
     end;
 
@@ -38,11 +48,17 @@ codeunit 82565 "ADLSE Credentials"
     end;
 
     procedure Check()
+    var
+        ADLSESetup: Record "ADLSE Setup";
     begin
         Init();
         CheckValueExists(TenantIdKeyNameTok, StorageTenantID);
         CheckValueExists(ClientIdKeyNameTok, ClientID);
-        CheckValueExists(ClientSecretKeyNameTok, ClientSecret);
+        ADLSESetup.GetSingleton();
+        if ADLSESetup."Use Certificate Authentication" then
+            CheckValueExists(ClientCertificateKeyNameTok, ClientCertificate)
+        else
+            CheckValueExists(ClientSecretKeyNameTok, ClientSecret);
     end;
 
     [NonDebuggable]
@@ -94,6 +110,38 @@ codeunit 82565 "ADLSE Credentials"
     procedure IsClientSecretSet(): Boolean
     begin
         exit(GetClientSecret() <> '');
+    end;
+
+    [NonDebuggable]
+    procedure GetClientCertificate(): Text
+    begin
+        exit(ClientCertificate);
+    end;
+
+    [NonDebuggable]
+    procedure SetClientCertificate(NewCertificateValue: Text): Text
+    begin
+        ClientCertificate := NewCertificateValue;
+        SetSecret(ClientCertificateKeyNameTok, NewCertificateValue);
+    end;
+
+    [NonDebuggable]
+    procedure IsClientCertificateSet(): Boolean
+    begin
+        exit(GetClientCertificate() <> '');
+    end;
+
+    [NonDebuggable]
+    procedure GetClientCertificatePassword(): Text
+    begin
+        exit(ClientCertificatePassword);
+    end;
+
+    [NonDebuggable]
+    procedure SetClientCertificatePassword(NewPasswordValue: Text): Text
+    begin
+        ClientCertificatePassword := NewPasswordValue;
+        SetSecret(ClientCertificatePasswordKeyNameTok, NewPasswordValue);
     end;
 
     [NonDebuggable]

--- a/businessCentral/app/src/Http.Codeunit.al
+++ b/businessCentral/app/src/Http.Codeunit.al
@@ -226,13 +226,12 @@ codeunit 82563 "ADLSE Http"
     end;
 
     [NonDebuggable]
-    local procedure AcquireTokenOAuth2(var AuthError: Text) AccessToken: Text
+    local procedure AcquireTokenOAuth2(var AuthError: Text) AccessToken: SecretText
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSETokenCache: Codeunit "ADLSE Token Cache";
         ADLSEUtil: Codeunit "ADLSE Util";
         OAuth2: Codeunit OAuth2;
-        AccessTokenSecret: SecretText;
         CertificateSecret: SecretText;
         CertificatePasswordSecret: SecretText;
         IdToken: Text;
@@ -269,10 +268,9 @@ codeunit 82563 "ADLSE Http"
             CertificatePasswordSecret := Credentials.GetClientCertificatePassword();
             OAuth2.AcquireTokensWithCertificate(
                 Credentials.GetClientID(), CertificateSecret, CertificatePasswordSecret,
-                '', OAuthAuthorityUrl, Scopes, AccessTokenSecret, IdToken);
+                '', OAuthAuthorityUrl, Scopes, AccessToken, IdToken);
 
-            AccessToken := AccessTokenSecret.Unwrap();
-            if AccessToken = '' then begin
+            if AccessToken.IsEmpty() then begin
                 AuthError := AcquireTokenFailedErr;
                 exit;
             end;

--- a/businessCentral/app/src/Http.Codeunit.al
+++ b/businessCentral/app/src/Http.Codeunit.al
@@ -19,9 +19,12 @@ codeunit 82563 "ADLSE Http"
         ContentTypeApplicationJsonTok: Label 'application/json', Locked = true;
         ContentTypePlainTextTok: Label 'text/plain; charset=utf-8', Locked = true;
         UnsupportedMethodErr: Label 'Unsupported method: %1', Comment = '%1: http method name';
+        OAuthTok: Label 'https://login.microsoftonline.com/%1/oauth2/token', Comment = '%1: tenant id', Locked = true;
         OAuthAuthorityTok: Label 'https://login.microsoftonline.com/%1', Comment = '%1: tenant id', Locked = true;
         BearerTok: Label 'Bearer %1', Comment = '%1: access token', Locked = true;
+        AcquireTokenBodyTok: Label 'resource=%1&scope=%2&client_id=%3&client_secret=%4&grant_type=client_credentials', Comment = '%1: encoded resource url, %2: encoded scope url, %3: client ID, %4: client secret', Locked = true;
         HttpRequestFailedErr: Label 'There was an error while executing the HTTP request, error request: %1.', Comment = '%1: error message';
+        AuthHttpRequestFailedErr: Label 'There was an error while acquiring the authentication token, error request: %1.', Comment = '%1: error message';
         AcquireTokenFailedErr: Label 'Failed to acquire an access token. Verify the credentials configured in the ADLSE Setup.';
 
     procedure SetMethod(HttpMethodValue: Enum "ADLSE Http Method")
@@ -227,47 +230,101 @@ codeunit 82563 "ADLSE Http"
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSETokenCache: Codeunit "ADLSE Token Cache";
+        ADLSEUtil: Codeunit "ADLSE Util";
         OAuth2: Codeunit OAuth2;
         AccessTokenSecret: SecretText;
-        ClientSecretText: SecretText;
         CertificateSecret: SecretText;
         CertificatePasswordSecret: SecretText;
         IdToken: Text;
         Scopes: List of [Text];
         OAuthAuthorityUrl: Text;
+        HttpClient: HttpClient;
+        HttpRequestMessage: HttpRequestMessage;
+        HttpContent: HttpContent;
+        Headers: HttpHeaders;
+        HttpResponseMessage: HttpResponseMessage;
+        Json: JsonObject;
+        Uri: Text;
+        RequestBody: Text;
+        ResponseBody: Text;
+        ScopeUrlEncoded: Text;
+        ExpiresInSeconds: Integer;
+        HttpRequestFailed: Boolean;
     begin
+        // Return cached token if still valid
         if ADLSETokenCache.IsTokenValid() then
             exit(ADLSETokenCache.GetCachedToken());
 
-        case ADLSESetup.GetStorageType() of
-            ADLSESetup."Storage Type"::"Azure Data Lake":
-                Scopes.Add('https://storage.azure.com/user_impersonation');
-            ADLSESetup."Storage Type"::"Microsoft Fabric":
-                Scopes.Add('https://storage.azure.com/.default');
-        end;
-
-        OAuthAuthorityUrl := StrSubstNo(OAuthAuthorityTok, Credentials.GetTenantID());
         ADLSESetup.GetSingleton();
         if ADLSESetup."Use Certificate Authentication" then begin
+            case ADLSESetup.GetStorageType() of
+                ADLSESetup."Storage Type"::"Azure Data Lake":
+                    Scopes.Add('https://storage.azure.com/user_impersonation');
+                ADLSESetup."Storage Type"::"Microsoft Fabric":
+                    Scopes.Add('https://storage.azure.com/.default');
+            end;
+
+            OAuthAuthorityUrl := StrSubstNo(OAuthAuthorityTok, Credentials.GetTenantID());
             CertificateSecret := Credentials.GetClientCertificate();
             CertificatePasswordSecret := Credentials.GetClientCertificatePassword();
             OAuth2.AcquireTokensWithCertificate(
                 Credentials.GetClientID(), CertificateSecret, CertificatePasswordSecret,
                 '', OAuthAuthorityUrl, Scopes, AccessTokenSecret, IdToken);
+
+            AccessToken := AccessTokenSecret.Unwrap();
+            if AccessToken = '' then begin
+                AuthError := AcquireTokenFailedErr;
+                exit;
+            end;
+
+            // Cache the token with a default 55-minute window (tokens typically last 1 hour)
+            ADLSETokenCache.SetToken(AccessToken, CurrentDateTime() + (55 * 60 * 1000));
         end else begin
-            ClientSecretText := Credentials.GetClientSecret();
-            OAuth2.AcquireTokenWithClientCredentials(
-                Credentials.GetClientID(), ClientSecretText,
-                OAuthAuthorityUrl, '', Scopes, AccessTokenSecret);
-        end;
+            case ADLSESetup.GetStorageType() of
+                ADLSESetup."Storage Type"::"Azure Data Lake":
+                    ScopeUrlEncoded := 'https%3A%2F%2Fstorage.azure.com%2Fuser_impersonation'; // url encoded form of https://storage.azure.com/user_impersonation
+                ADLSESetup."Storage Type"::"Microsoft Fabric":
+                    ScopeUrlEncoded := 'https%3A%2F%2Fstorage.azure.com%2F.default'; // url encoded form of https://storage.azure.com/.default                
+            end;
 
-        AccessToken := AccessTokenSecret.Unwrap();
-        if AccessToken = '' then begin
-            AuthError := AcquireTokenFailedErr;
-            exit;
-        end;
+            Uri := StrSubstNo(OAuthTok, Credentials.GetTenantID());
+            HttpRequestMessage.Method('POST');
+            HttpRequestMessage.SetRequestUri(Uri);
 
-        // Cache the token with a default 55-minute window (tokens typically last 1 hour)
-        ADLSETokenCache.SetToken(AccessToken, CurrentDateTime() + (55 * 60 * 1000));
+            RequestBody :=
+                StrSubstNo(
+                    AcquireTokenBodyTok,
+                    'https%3A%2F%2Fstorage.azure.com%2F', // url encoded form of https://storage.azure.com/
+                    ScopeUrlEncoded,
+                    Credentials.GetClientID(),
+                    Credentials.GetClientSecret());
+
+            HttpContent.WriteFrom(RequestBody);
+            HttpContent.GetHeaders(Headers);
+            Headers.Remove('Content-Type');
+            Headers.Add('Content-Type', 'application/x-www-form-urlencoded');
+
+            HttpRequestFailed := not HttpClient.Post(Uri, HttpContent, HttpResponseMessage);
+            if HttpRequestFailed then begin
+                AuthError := StrSubstNo(AuthHttpRequestFailedErr, HttpResponseMessage.ReasonPhrase());
+                exit;
+            end;
+
+            HttpContent := HttpResponseMessage.Content();
+            HttpContent.ReadAs(ResponseBody);
+            if not HttpResponseMessage.IsSuccessStatusCode() then begin
+                AuthError := ResponseBody;
+                exit;
+            end;
+
+            Json.ReadFrom(ResponseBody);
+            AccessToken := ADLSEUtil.GetTextValueForKeyInJson(Json, 'access_token');
+
+            // Cache the token with expiry (subtract 5 minutes for safety margin)
+            // expires_in is in seconds, default to 3600 (1 hour) if not present
+            if not Evaluate(ExpiresInSeconds, ADLSEUtil.GetTextValueForKeyInJson(Json, 'expires_in')) then
+                ExpiresInSeconds := 3600;
+            ADLSETokenCache.SetToken(AccessToken, CurrentDateTime() + (ExpiresInSeconds * 1000) - (5 * 60 * 1000));
+        end;
     end;
 }

--- a/businessCentral/app/src/Http.Codeunit.al
+++ b/businessCentral/app/src/Http.Codeunit.al
@@ -256,12 +256,9 @@ codeunit 82563 "ADLSE Http"
 
         ADLSESetup.GetSingleton();
         if ADLSESetup."Use Certificate Authentication" then begin
-            case ADLSESetup.GetStorageType() of
-                ADLSESetup."Storage Type"::"Azure Data Lake":
-                    Scopes.Add('https://storage.azure.com/user_impersonation');
-                ADLSESetup."Storage Type"::"Microsoft Fabric":
-                    Scopes.Add('https://storage.azure.com/.default');
-            end;
+            // Certificate auth is always a service principal (client credentials) flow,
+            // which requires the .default scope regardless of storage type.
+            Scopes.Add('https://storage.azure.com/.default');
 
             OAuthAuthorityUrl := StrSubstNo(OAuthAuthorityTok, Credentials.GetTenantID());
             CertificateSecret := Credentials.GetClientCertificate();

--- a/businessCentral/app/src/Http.Codeunit.al
+++ b/businessCentral/app/src/Http.Codeunit.al
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 namespace bc2adls;
 
-using System.Security.Cryptography.X509Certificates;
-using System.Security.Cryptography;
-using System.Utilities;
+using System.Security.Authentication;
 codeunit 82563 "ADLSE Http"
 {
     Access = Internal;
@@ -21,16 +19,10 @@ codeunit 82563 "ADLSE Http"
         ContentTypeApplicationJsonTok: Label 'application/json', Locked = true;
         ContentTypePlainTextTok: Label 'text/plain; charset=utf-8', Locked = true;
         UnsupportedMethodErr: Label 'Unsupported method: %1', Comment = '%1: http method name';
-        OAuthTok: Label 'https://login.microsoftonline.com/%1/oauth2/token', Comment = '%1: tenant id', Locked = true;
+        OAuthAuthorityTok: Label 'https://login.microsoftonline.com/%1', Comment = '%1: tenant id', Locked = true;
         BearerTok: Label 'Bearer %1', Comment = '%1: access token', Locked = true;
-        AcquireTokenBodyTok: Label 'resource=%1&scope=%2&client_id=%3&client_secret=%4&grant_type=client_credentials', Comment = '%1: encoded resource url, %2: encoded scope url, %3: client ID, %4: client secret', Locked = true;
-        AcquireTokenCertBodyTok: Label 'resource=%1&scope=%2&client_id=%3&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=%4&grant_type=client_credentials', Comment = '%1: encoded resource url, %2: encoded scope url, %3: client ID, %4: JWT assertion', Locked = true;
-        JwtHeaderTok: Label '{"alg":"RS256","typ":"JWT","x5t":"%1"}', Comment = '%1: base64url-encoded SHA-1 thumbprint', Locked = true;
-        JwtPayloadTok: Label '{"aud":"%1","exp":%2,"iss":"%3","jti":"%4","nbf":%5,"sub":"%6"}', Comment = '%1: audience, %2: expiry unix time, %3: issuer (client id), %4: jti guid, %5: not-before unix time, %6: subject (client id)', Locked = true;
         HttpRequestFailedErr: Label 'There was an error while executing the HTTP request, error request: %1.', Comment = '%1: error message';
-        AuthHttpRequestFailedErr: Label 'There was an error while acquiring the authentication token, error request: %1.', Comment = '%1: error message';
-        CertificateLoadFailedErr: Label 'Could not load the certificate for authentication. Verify the certificate Base64 value and password.';
-        InvalidCertificatePrivateKeyErr: Label 'Could not retrieve the private key from the certificate. Ensure the PFX contains a private key.';
+        AcquireTokenFailedErr: Label 'Failed to acquire an access token. Verify the credentials configured in the ADLSE Setup.';
 
     procedure SetMethod(HttpMethodValue: Enum "ADLSE Http Method")
     begin
@@ -235,177 +227,47 @@ codeunit 82563 "ADLSE Http"
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSETokenCache: Codeunit "ADLSE Token Cache";
-        ADLSEUtil: Codeunit "ADLSE Util";
-        HttpClient: HttpClient;
-        HttpRequestMessage: HttpRequestMessage;
-        HttpContent: HttpContent;
-        Headers: HttpHeaders;
-        HttpResponseMessage: HttpResponseMessage;
-        Json: JsonObject;
-        Uri: Text;
-        RequestBody: Text;
-        ResponseBody: Text;
-        ScopeUrlEncoded: Text;
-        ExpiresInSeconds: Integer;
-        HttpRequestFailed: Boolean;
+        OAuth2: Codeunit OAuth2;
+        AccessTokenSecret: SecretText;
+        ClientSecretText: SecretText;
+        CertificateSecret: SecretText;
+        CertificatePasswordSecret: SecretText;
+        IdToken: Text;
+        Scopes: List of [Text];
+        OAuthAuthorityUrl: Text;
     begin
-        // Return cached token if still valid
         if ADLSETokenCache.IsTokenValid() then
             exit(ADLSETokenCache.GetCachedToken());
 
         case ADLSESetup.GetStorageType() of
             ADLSESetup."Storage Type"::"Azure Data Lake":
-                ScopeUrlEncoded := 'https%3A%2F%2Fstorage.azure.com%2Fuser_impersonation'; // url encoded form of https://storage.azure.com/user_impersonation
+                Scopes.Add('https://storage.azure.com/user_impersonation');
             ADLSESetup."Storage Type"::"Microsoft Fabric":
-                ScopeUrlEncoded := 'https%3A%2F%2Fstorage.azure.com%2F.default'; // url encoded form of https://storage.azure.com/.default                
+                Scopes.Add('https://storage.azure.com/.default');
         end;
 
-        Uri := StrSubstNo(OAuthTok, Credentials.GetTenantID());
-        HttpRequestMessage.Method('POST');
-        HttpRequestMessage.SetRequestUri(Uri);
-
+        OAuthAuthorityUrl := StrSubstNo(OAuthAuthorityTok, Credentials.GetTenantID());
         ADLSESetup.GetSingleton();
-        if ADLSESetup."Use Certificate Authentication" then
-            RequestBody := BuildCertificateTokenRequestBody(ScopeUrlEncoded, Uri, AuthError)
-        else
-            RequestBody :=
-                StrSubstNo(
-                    AcquireTokenBodyTok,
-                    'https%3A%2F%2Fstorage.azure.com%2F', // url encoded form of https://storage.azure.com/
-                    ScopeUrlEncoded,
-                    Credentials.GetClientID(),
-                    Credentials.GetClientSecret());
+        if ADLSESetup."Use Certificate Authentication" then begin
+            CertificateSecret := Credentials.GetClientCertificate();
+            CertificatePasswordSecret := Credentials.GetClientCertificatePassword();
+            OAuth2.AcquireTokensWithCertificate(
+                Credentials.GetClientID(), CertificateSecret, CertificatePasswordSecret,
+                '', OAuthAuthorityUrl, Scopes, AccessTokenSecret, IdToken);
+        end else begin
+            ClientSecretText := Credentials.GetClientSecret();
+            OAuth2.AcquireTokenWithClientCredentials(
+                Credentials.GetClientID(), ClientSecretText,
+                OAuthAuthorityUrl, '', Scopes, AccessTokenSecret);
+        end;
 
-        if RequestBody = '' then
-            exit; // AuthError already set
-
-        HttpContent.WriteFrom(RequestBody);
-        HttpContent.GetHeaders(Headers);
-        Headers.Remove('Content-Type');
-        Headers.Add('Content-Type', 'application/x-www-form-urlencoded');
-
-        HttpRequestFailed := not HttpClient.Post(Uri, HttpContent, HttpResponseMessage);
-        if HttpRequestFailed then begin
-            AuthError := StrSubstNo(AuthHttpRequestFailedErr, HttpResponseMessage.ReasonPhrase());
+        AccessToken := AccessTokenSecret.Unwrap();
+        if AccessToken = '' then begin
+            AuthError := AcquireTokenFailedErr;
             exit;
         end;
 
-        HttpContent := HttpResponseMessage.Content();
-        HttpContent.ReadAs(ResponseBody);
-        if not HttpResponseMessage.IsSuccessStatusCode() then begin
-            AuthError := ResponseBody;
-            exit;
-        end;
-
-        Json.ReadFrom(ResponseBody);
-        AccessToken := ADLSEUtil.GetTextValueForKeyInJson(Json, 'access_token');
-
-        // Cache the token with expiry (subtract 5 minutes for safety margin)
-        // expires_in is in seconds, default to 3600 (1 hour) if not present
-        if not Evaluate(ExpiresInSeconds, ADLSEUtil.GetTextValueForKeyInJson(Json, 'expires_in')) then
-            ExpiresInSeconds := 3600;
-        ADLSETokenCache.SetToken(AccessToken, CurrentDateTime() + (ExpiresInSeconds * 1000) - (5 * 60 * 1000));
-    end;
-
-    [NonDebuggable]
-    local procedure BuildCertificateTokenRequestBody(ScopeUrlEncoded: Text; AudienceUri: Text; var AuthError: Text) RequestBody: Text
-    var
-        X509Cert: Codeunit "X509Certificate2";
-        RSA: Codeunit "RSACryptoServiceProvider";
-        CertBase64: Text;
-        CertPasswordText: Text;
-        CertPassword: SecretText;
-        CertThumbprintBase64Url: Text;
-        PrivateKeyXml: Text;
-        JwtHeader: Text;
-        JwtPayload: Text;
-        JwtHeaderEncoded: Text;
-        JwtPayloadEncoded: Text;
-        JwtSigningInput: Text;
-        SignatureBase64: Text;
-        JwtAssertion: Text;
-        NowUnix: BigInteger;
-        ExpUnix: BigInteger;
-        Jti: Text;
-    begin
-        CertBase64 := Credentials.GetClientCertificate();
-        CertPasswordText := Credentials.GetClientCertificatePassword();
-        CertPassword := CertPasswordText;
-
-        if not X509Cert.VerifyCertificate(CertBase64, CertPassword, Enum::"X509 Content Type"::Pfx, AuthError) then begin
-            AuthError := CertificateLoadFailedErr + ' ' + AuthError;
-            exit('');
-        end;
-
-        // The hex thumbprint (SHA-1) is base64url-encoded to produce the JWT x5t header value
-        CertThumbprintBase64Url := HexToBase64Url(X509Cert.GetCertificateThumbprint(CertBase64, CertPassword, false));
-
-        if not X509Cert.GetCertificatePrivateKey(CertBase64, CertPassword, PrivateKeyXml) then begin
-            AuthError := InvalidCertificatePrivateKeyErr;
-            exit('');
-        end;
-
-        // Current time as Unix epoch (seconds)
-        NowUnix := Round((CurrentDateTime() - CreateDateTime(DMY2Date(1, 1, 1970), 0T)) / 1000, 1, '<');
-        ExpUnix := NowUnix + 600; // 10-minute assertion lifetime
-        Jti := Format(CreateGuid());
-
-        JwtHeader := StrSubstNo(JwtHeaderTok, CertThumbprintBase64Url);
-        JwtPayload := StrSubstNo(JwtPayloadTok, AudienceUri, ExpUnix, Credentials.GetClientID(), Jti, NowUnix, Credentials.GetClientID());
-
-        JwtHeaderEncoded := Base64UrlEncode(JwtHeader);
-        JwtPayloadEncoded := Base64UrlEncode(JwtPayload);
-        JwtSigningInput := JwtHeaderEncoded + '.' + JwtPayloadEncoded;
-
-        RSA.FromXmlString(PrivateKeyXml);
-        if not RSA.SignData(JwtSigningInput, Enum::"Hash Algorithm"::SHA256, Enum::"RSA Signature Padding"::Pkcs1, SignatureBase64) then begin
-            AuthError := InvalidCertificatePrivateKeyErr;
-            exit('');
-        end;
-        SignatureBase64 := SignatureBase64.Replace('+', '-').Replace('/', '_').Replace('=', '');
-
-        JwtAssertion := JwtSigningInput + '.' + SignatureBase64;
-
-        RequestBody :=
-            StrSubstNo(
-                AcquireTokenCertBodyTok,
-                'https%3A%2F%2Fstorage.azure.com%2F',
-                ScopeUrlEncoded,
-                Credentials.GetClientID(),
-                JwtAssertion);
-    end;
-
-    [NonDebuggable]
-    local procedure Base64UrlEncode(InputText: Text) Encoded: Text
-    var
-        Base64: Codeunit "Base64 Convert";
-    begin
-        Encoded := Base64.ToBase64(InputText);
-        Encoded := Encoded.Replace('+', '-').Replace('/', '_').Replace('=', '');
-    end;
-
-    // Converts a hex-encoded byte string (e.g. SHA-1 thumbprint) to base64url encoding.
-    local procedure HexToBase64Url(HexString: Text) Result: Text
-    var
-        Base64: Codeunit "Base64 Convert";
-        TempBlob: Codeunit "Temp Blob";
-        OStream: OutStream;
-        IStream: InStream;
-        HexDigits: Text;
-        I: Integer;
-        ByteVal: Integer;
-    begin
-        HexDigits := '0123456789abcdef';
-        HexString := LowerCase(HexString);
-        TempBlob.CreateOutStream(OStream);
-        for I := 1 to StrLen(HexString) div 2 do begin
-            ByteVal :=
-                (StrPos(HexDigits, CopyStr(HexString, (I - 1) * 2 + 1, 1)) - 1) * 16 +
-                (StrPos(HexDigits, CopyStr(HexString, (I - 1) * 2 + 2, 1)) - 1);
-            OStream.Write(ByteVal, 1);
-        end;
-        TempBlob.CreateInStream(IStream);
-        Result := Base64.ToBase64(IStream);
-        Result := Result.Replace('+', '-').Replace('/', '_').Replace('=', '');
+        // Cache the token with a default 55-minute window (tokens typically last 1 hour)
+        ADLSETokenCache.SetToken(AccessToken, CurrentDateTime() + (55 * 60 * 1000));
     end;
 }

--- a/businessCentral/app/src/Http.Codeunit.al
+++ b/businessCentral/app/src/Http.Codeunit.al
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 namespace bc2adls;
+
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography;
+using System.Utilities;
 codeunit 82563 "ADLSE Http"
 {
     Access = Internal;
@@ -20,8 +24,13 @@ codeunit 82563 "ADLSE Http"
         OAuthTok: Label 'https://login.microsoftonline.com/%1/oauth2/token', Comment = '%1: tenant id', Locked = true;
         BearerTok: Label 'Bearer %1', Comment = '%1: access token', Locked = true;
         AcquireTokenBodyTok: Label 'resource=%1&scope=%2&client_id=%3&client_secret=%4&grant_type=client_credentials', Comment = '%1: encoded resource url, %2: encoded scope url, %3: client ID, %4: client secret', Locked = true;
+        AcquireTokenCertBodyTok: Label 'resource=%1&scope=%2&client_id=%3&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=%4&grant_type=client_credentials', Comment = '%1: encoded resource url, %2: encoded scope url, %3: client ID, %4: JWT assertion', Locked = true;
+        JwtHeaderTok: Label '{"alg":"RS256","typ":"JWT","x5t":"%1"}', Comment = '%1: base64url-encoded SHA-1 thumbprint', Locked = true;
+        JwtPayloadTok: Label '{"aud":"%1","exp":%2,"iss":"%3","jti":"%4","nbf":%5,"sub":"%6"}', Comment = '%1: audience, %2: expiry unix time, %3: issuer (client id), %4: jti guid, %5: not-before unix time, %6: subject (client id)', Locked = true;
         HttpRequestFailedErr: Label 'There was an error while executing the HTTP request, error request: %1.', Comment = '%1: error message';
         AuthHttpRequestFailedErr: Label 'There was an error while acquiring the authentication token, error request: %1.', Comment = '%1: error message';
+        CertificateLoadFailedErr: Label 'Could not load the certificate for authentication. Verify the certificate Base64 value and password.';
+        InvalidCertificatePrivateKeyErr: Label 'Could not retrieve the private key from the certificate. Ensure the PFX contains a private key.';
 
     procedure SetMethod(HttpMethodValue: Enum "ADLSE Http Method")
     begin
@@ -254,13 +263,22 @@ codeunit 82563 "ADLSE Http"
         Uri := StrSubstNo(OAuthTok, Credentials.GetTenantID());
         HttpRequestMessage.Method('POST');
         HttpRequestMessage.SetRequestUri(Uri);
-        RequestBody :=
-        StrSubstNo(
+
+        ADLSESetup.GetSingleton();
+        if ADLSESetup."Use Certificate Authentication" then
+            RequestBody := BuildCertificateTokenRequestBody(ScopeUrlEncoded, Uri, AuthError)
+        else
+            RequestBody :=
+                StrSubstNo(
                     AcquireTokenBodyTok,
                     'https%3A%2F%2Fstorage.azure.com%2F', // url encoded form of https://storage.azure.com/
                     ScopeUrlEncoded,
                     Credentials.GetClientID(),
                     Credentials.GetClientSecret());
+
+        if RequestBody = '' then
+            exit; // AuthError already set
+
         HttpContent.WriteFrom(RequestBody);
         HttpContent.GetHeaders(Headers);
         Headers.Remove('Content-Type');
@@ -287,5 +305,107 @@ codeunit 82563 "ADLSE Http"
         if not Evaluate(ExpiresInSeconds, ADLSEUtil.GetTextValueForKeyInJson(Json, 'expires_in')) then
             ExpiresInSeconds := 3600;
         ADLSETokenCache.SetToken(AccessToken, CurrentDateTime() + (ExpiresInSeconds * 1000) - (5 * 60 * 1000));
+    end;
+
+    [NonDebuggable]
+    local procedure BuildCertificateTokenRequestBody(ScopeUrlEncoded: Text; AudienceUri: Text; var AuthError: Text) RequestBody: Text
+    var
+        X509Cert: Codeunit "X509Certificate2";
+        RSA: Codeunit "RSACryptoServiceProvider";
+        CertBase64: Text;
+        CertPasswordText: Text;
+        CertPassword: SecretText;
+        CertThumbprintBase64Url: Text;
+        PrivateKeyXml: Text;
+        JwtHeader: Text;
+        JwtPayload: Text;
+        JwtHeaderEncoded: Text;
+        JwtPayloadEncoded: Text;
+        JwtSigningInput: Text;
+        SignatureBase64: Text;
+        JwtAssertion: Text;
+        NowUnix: BigInteger;
+        ExpUnix: BigInteger;
+        Jti: Text;
+    begin
+        CertBase64 := Credentials.GetClientCertificate();
+        CertPasswordText := Credentials.GetClientCertificatePassword();
+        CertPassword := CertPasswordText;
+
+        if not X509Cert.VerifyCertificate(CertBase64, CertPassword, Enum::"X509 Content Type"::Pfx, AuthError) then begin
+            AuthError := CertificateLoadFailedErr + ' ' + AuthError;
+            exit('');
+        end;
+
+        // The hex thumbprint (SHA-1) is base64url-encoded to produce the JWT x5t header value
+        CertThumbprintBase64Url := HexToBase64Url(X509Cert.GetCertificateThumbprint(CertBase64, CertPassword, false));
+
+        if not X509Cert.GetCertificatePrivateKey(CertBase64, CertPassword, PrivateKeyXml) then begin
+            AuthError := InvalidCertificatePrivateKeyErr;
+            exit('');
+        end;
+
+        // Current time as Unix epoch (seconds)
+        NowUnix := Round((CurrentDateTime() - CreateDateTime(DMY2Date(1, 1, 1970), 0T)) / 1000, 1, '<');
+        ExpUnix := NowUnix + 600; // 10-minute assertion lifetime
+        Jti := Format(CreateGuid());
+
+        JwtHeader := StrSubstNo(JwtHeaderTok, CertThumbprintBase64Url);
+        JwtPayload := StrSubstNo(JwtPayloadTok, AudienceUri, ExpUnix, Credentials.GetClientID(), Jti, NowUnix, Credentials.GetClientID());
+
+        JwtHeaderEncoded := Base64UrlEncode(JwtHeader);
+        JwtPayloadEncoded := Base64UrlEncode(JwtPayload);
+        JwtSigningInput := JwtHeaderEncoded + '.' + JwtPayloadEncoded;
+
+        RSA.FromXmlString(PrivateKeyXml);
+        if not RSA.SignData(JwtSigningInput, Enum::"Hash Algorithm"::SHA256, Enum::"RSA Signature Padding"::Pkcs1, SignatureBase64) then begin
+            AuthError := InvalidCertificatePrivateKeyErr;
+            exit('');
+        end;
+        SignatureBase64 := SignatureBase64.Replace('+', '-').Replace('/', '_').Replace('=', '');
+
+        JwtAssertion := JwtSigningInput + '.' + SignatureBase64;
+
+        RequestBody :=
+            StrSubstNo(
+                AcquireTokenCertBodyTok,
+                'https%3A%2F%2Fstorage.azure.com%2F',
+                ScopeUrlEncoded,
+                Credentials.GetClientID(),
+                JwtAssertion);
+    end;
+
+    [NonDebuggable]
+    local procedure Base64UrlEncode(InputText: Text) Encoded: Text
+    var
+        Base64: Codeunit "Base64 Convert";
+    begin
+        Encoded := Base64.ToBase64(InputText);
+        Encoded := Encoded.Replace('+', '-').Replace('/', '_').Replace('=', '');
+    end;
+
+    // Converts a hex-encoded byte string (e.g. SHA-1 thumbprint) to base64url encoding.
+    local procedure HexToBase64Url(HexString: Text) Result: Text
+    var
+        Base64: Codeunit "Base64 Convert";
+        TempBlob: Codeunit "Temp Blob";
+        OStream: OutStream;
+        IStream: InStream;
+        HexDigits: Text;
+        I: Integer;
+        ByteVal: Integer;
+    begin
+        HexDigits := '0123456789abcdef';
+        HexString := LowerCase(HexString);
+        TempBlob.CreateOutStream(OStream);
+        for I := 1 to StrLen(HexString) div 2 do begin
+            ByteVal :=
+                (StrPos(HexDigits, CopyStr(HexString, (I - 1) * 2 + 1, 1)) - 1) * 16 +
+                (StrPos(HexDigits, CopyStr(HexString, (I - 1) * 2 + 2, 1)) - 1);
+            OStream.Write(ByteVal, 1);
+        end;
+        TempBlob.CreateInStream(IStream);
+        Result := Base64.ToBase64(IStream);
+        Result := Result.Replace('+', '-').Replace('/', '_').Replace('=', '');
     end;
 }

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -83,15 +83,50 @@ page 82560 "ADLSE Setup"
                             ADLSECredentials.SetClientID(ClientID);
                         end;
                     }
+                    field(UseCertificateAuthentication; Rec."Use Certificate Authentication")
+                    {
+                        Caption = 'Use Certificate Authentication';
+                        ToolTip = 'Specifies whether to use a certificate for OAuth2 authentication instead of a client secret.';
+
+                        trigger OnValidate()
+                        begin
+                            CurrPage.Update(true);
+                        end;
+                    }
                     field("Client secret"; ClientSecret)
                     {
                         Caption = 'Client secret';
                         ExtendedDatatype = Masked;
                         ToolTip = 'Specifies the client secret for the Azure App Registration that accesses the storage account.';
+                        Visible = not Rec."Use Certificate Authentication";
 
                         trigger OnValidate()
                         begin
                             ADLSECredentials.SetClientSecret(ClientSecret);
+                        end;
+                    }
+                    field(ClientCertificate; ClientCertificate)
+                    {
+                        Caption = 'Certificate (Base64 PFX)';
+                        ExtendedDatatype = Masked;
+                        ToolTip = 'Specifies the Base64-encoded PFX certificate used for OAuth2 authentication.';
+                        Visible = Rec."Use Certificate Authentication";
+
+                        trigger OnValidate()
+                        begin
+                            ADLSECredentials.SetClientCertificate(ClientCertificate);
+                        end;
+                    }
+                    field(ClientCertificatePassword; ClientCertificatePassword)
+                    {
+                        Caption = 'Certificate Password';
+                        ExtendedDatatype = Masked;
+                        ToolTip = 'Specifies the password for the PFX certificate.';
+                        Visible = Rec."Use Certificate Authentication";
+
+                        trigger OnValidate()
+                        begin
+                            ADLSECredentials.SetClientCertificatePassword(ClientCertificatePassword);
                         end;
                     }
                 }
@@ -398,6 +433,8 @@ page 82560 "ADLSE Setup"
         FabricOpenMirroring, AzureDataLake : Boolean;
         ClientSecretLbl: Label 'Secret not shown';
         ClientIdLbl: Label 'ID not shown';
+        CertificateSetLbl: Label 'Certificate set';
+        CertificatePasswordSetLbl: Label 'Password set';
 
     trigger OnInit()
     begin
@@ -408,6 +445,10 @@ page 82560 "ADLSE Setup"
             ClientID := ClientIdLbl;
         if ADLSECredentials.IsClientSecretSet() then
             ClientSecret := ClientSecretLbl;
+        if ADLSECredentials.IsClientCertificateSet() then
+            ClientCertificate := CertificateSetLbl;
+        if ADLSECredentials.GetClientCertificatePassword() <> '' then
+            ClientCertificatePassword := CertificatePasswordSetLbl;
     end;
 
     trigger OnAfterGetRecord()
@@ -434,6 +475,10 @@ page 82560 "ADLSE Setup"
         ClientID: Text;
         [NonDebuggable]
         ClientSecret: Text;
+        [NonDebuggable]
+        ClientCertificate: Text;
+        [NonDebuggable]
+        ClientCertificatePassword: Text;
         OldLogsExist: Boolean;
         FailureNotificationID: Guid;
         ExportFailureNotificationMsg: Label 'Data from one or more tables failed to export on the last run. Please check the tables below to see the error(s).';

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -4,6 +4,7 @@ namespace bc2adls;
 
 using System.Globalization;
 using System.Threading;
+using System.Text;
 page 82560 "ADLSE Setup"
 {
     PageType = Card;

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -95,44 +95,53 @@ page 82560 "ADLSE Setup"
                             CurrPage.Update(true);
                         end;
                     }
-                    field("Client secret"; ClientSecret)
+                    group(SecretAuthGroup)
                     {
-                        Caption = 'Client secret';
-                        ExtendedDatatype = Masked;
-                        ToolTip = 'Specifies the client secret for the Azure App Registration that accesses the storage account.';
+                        ShowCaption = false;
                         Visible = SecretVisible;
 
-                        trigger OnValidate()
-                        begin
-                            ADLSECredentials.SetClientSecret(ClientSecret);
-                            CurrPage.Update(true);
-                        end;
-                    }
-                    field(CertificateUploadStatus; CertificateStatusText)
-                    {
-                        Caption = 'Certificate';
-                        Editable = false;
-                        Visible = CertificateVisible;
-                        ToolTip = 'Specifies the PFX certificate used for OAuth2 authentication. Click to upload a new certificate file (.pfx or .p12).';
+                        field("Client secret"; ClientSecret)
+                        {
+                            Caption = 'Client secret';
+                            ExtendedDatatype = Masked;
+                            ToolTip = 'Specifies the client secret for the Azure App Registration that accesses the storage account.';
 
-                        trigger OnDrillDown()
-                        begin
-                            UploadCertificate();
-                            UpdateCertificateStatus();
-                            CurrPage.Update(false);
-                        end;
+                            trigger OnValidate()
+                            begin
+                                ADLSECredentials.SetClientSecret(ClientSecret);
+                                CurrPage.Update(true);
+                            end;
+                        }
                     }
-                    field(ClientCertificatePassword; ClientCertificatePassword)
+                    group(CertAuthGroup)
                     {
-                        Caption = 'Certificate Password';
-                        ExtendedDatatype = Masked;
-                        ToolTip = 'Specifies the password for the PFX certificate.';
+                        ShowCaption = false;
                         Visible = CertificateVisible;
 
-                        trigger OnValidate()
-                        begin
-                            ADLSECredentials.SetClientCertificatePassword(ClientCertificatePassword);
-                        end;
+                        field(CertificateUploadStatus; CertificateStatusText)
+                        {
+                            Caption = 'Certificate';
+                            Editable = false;
+                            ToolTip = 'Specifies the PFX certificate used for OAuth2 authentication. Click to upload a new certificate file (.pfx or .p12).';
+
+                            trigger OnDrillDown()
+                            begin
+                                UploadCertificate();
+                                UpdateCertificateStatus();
+                                CurrPage.Update(false);
+                            end;
+                        }
+                        field(ClientCertificatePassword; ClientCertificatePassword)
+                        {
+                            Caption = 'Certificate Password';
+                            ExtendedDatatype = Masked;
+                            ToolTip = 'Specifies the password for the PFX certificate.';
+
+                            trigger OnValidate()
+                            begin
+                                ADLSECredentials.SetClientCertificatePassword(ClientCertificatePassword);
+                            end;
+                        }
                     }
                 }
             }

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -90,6 +90,7 @@ page 82560 "ADLSE Setup"
 
                         trigger OnValidate()
                         begin
+                            UpdateAuthVisibility();
                             CurrPage.Update(true);
                         end;
                     }
@@ -98,23 +99,25 @@ page 82560 "ADLSE Setup"
                         Caption = 'Client secret';
                         ExtendedDatatype = Masked;
                         ToolTip = 'Specifies the client secret for the Azure App Registration that accesses the storage account.';
-                        Visible = not Rec."Use Certificate Authentication";
+                        Visible = SecretVisible;
 
                         trigger OnValidate()
                         begin
                             ADLSECredentials.SetClientSecret(ClientSecret);
                         end;
                     }
-                    field(ClientCertificate; ClientCertificate)
+                    field(CertificateUploadStatus; CertificateStatusText)
                     {
-                        Caption = 'Certificate (Base64 PFX)';
-                        ExtendedDatatype = Masked;
-                        ToolTip = 'Specifies the Base64-encoded PFX certificate used for OAuth2 authentication.';
-                        Visible = Rec."Use Certificate Authentication";
+                        Caption = 'Certificate';
+                        Editable = false;
+                        Visible = CertificateVisible;
+                        ToolTip = 'Specifies the PFX certificate used for OAuth2 authentication. Click to upload a new certificate file (.pfx or .p12).';
 
-                        trigger OnValidate()
+                        trigger OnDrillDown()
                         begin
-                            ADLSECredentials.SetClientCertificate(ClientCertificate);
+                            UploadCertificate();
+                            UpdateCertificateStatus();
+                            CurrPage.Update(false);
                         end;
                     }
                     field(ClientCertificatePassword; ClientCertificatePassword)
@@ -122,7 +125,7 @@ page 82560 "ADLSE Setup"
                         Caption = 'Certificate Password';
                         ExtendedDatatype = Masked;
                         ToolTip = 'Specifies the password for the PFX certificate.';
-                        Visible = Rec."Use Certificate Authentication";
+                        Visible = CertificateVisible;
 
                         trigger OnValidate()
                         begin
@@ -431,10 +434,11 @@ page 82560 "ADLSE Setup"
 
     var
         FabricOpenMirroring, AzureDataLake : Boolean;
+        CertificateVisible, SecretVisible : Boolean;
         ClientSecretLbl: Label 'Secret not shown';
         ClientIdLbl: Label 'ID not shown';
-        CertificateSetLbl: Label 'Certificate set';
         CertificatePasswordSetLbl: Label 'Password set';
+        CertificateStatusText: Text;
 
     trigger OnInit()
     begin
@@ -445,10 +449,10 @@ page 82560 "ADLSE Setup"
             ClientID := ClientIdLbl;
         if ADLSECredentials.IsClientSecretSet() then
             ClientSecret := ClientSecretLbl;
-        if ADLSECredentials.IsClientCertificateSet() then
-            ClientCertificate := CertificateSetLbl;
         if ADLSECredentials.GetClientCertificatePassword() <> '' then
             ClientCertificatePassword := CertificatePasswordSetLbl;
+        UpdateAuthVisibility();
+        UpdateCertificateStatus();
     end;
 
     trigger OnAfterGetRecord()
@@ -476,12 +480,42 @@ page 82560 "ADLSE Setup"
         [NonDebuggable]
         ClientSecret: Text;
         [NonDebuggable]
-        ClientCertificate: Text;
-        [NonDebuggable]
         ClientCertificatePassword: Text;
         OldLogsExist: Boolean;
         FailureNotificationID: Guid;
         ExportFailureNotificationMsg: Label 'Data from one or more tables failed to export on the last run. Please check the tables below to see the error(s).';
+
+    local procedure UpdateAuthVisibility()
+    begin
+        CertificateVisible := Rec."Use Certificate Authentication";
+        SecretVisible := not Rec."Use Certificate Authentication";
+    end;
+
+    local procedure UpdateCertificateStatus()
+    var
+        NoCertificateLbl: Label 'No certificate (click to upload)';
+        CertificateUploadedLbl: Label 'Certificate uploaded (click to change)';
+    begin
+        if ADLSECredentials.IsClientCertificateSet() then
+            CertificateStatusText := CertificateUploadedLbl
+        else
+            CertificateStatusText := NoCertificateLbl;
+    end;
+
+    [NonDebuggable]
+    local procedure UploadCertificate()
+    var
+        Base64Convert: Codeunit "Base64 Convert";
+        InStr: InStream;
+        CertificateBase64: Text;
+        CertificateFilterTxt: Label 'Certificate Files (*.pfx;*.p12)|*.pfx;*.p12|All Files (*.*)|*.*', Locked = true;
+        FileNotUploadedErr: Label 'Certificate file was not uploaded.';
+    begin
+        if not UploadIntoStream(CertificateFilterTxt, InStr) then
+            Error(FileNotUploadedErr);
+        CertificateBase64 := Base64Convert.ToBase64(InStr);
+        ADLSECredentials.SetClientCertificate(CertificateBase64);
+    end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'r')]
     local procedure UpdateNotificationIfAnyTableExportFailed()

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -105,6 +105,7 @@ page 82560 "ADLSE Setup"
                         trigger OnValidate()
                         begin
                             ADLSECredentials.SetClientSecret(ClientSecret);
+                            CurrPage.Update(true);
                         end;
                     }
                     field(CertificateUploadStatus; CertificateStatusText)
@@ -468,6 +469,8 @@ page 82560 "ADLSE Setup"
         UpdateNotificationIfAnyTableExportFailed();
         AzureDataLake := Rec."Storage Type" = Rec."Storage Type"::"Azure Data Lake";
         FabricOpenMirroring := Rec."Storage Type" = Rec."Storage Type"::"Open Mirroring";
+        UpdateAuthVisibility();
+        UpdateCertificateStatus();
     end;
 
     var

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -223,6 +223,12 @@ table 82560 "ADLSE Setup"
             ToolTip = 'Specifies if you want to export the closing date column in G/L Entries.';
             InitValue = false;
         }
+        field(105; "Use Certificate Authentication"; Boolean)
+        {
+            Caption = 'Use Certificate Authentication';
+            ToolTip = 'Specifies if a certificate will be used for OAuth2 authentication instead of a client secret.';
+            InitValue = false;
+        }
     }
 
     keys

--- a/businessCentral/app/src/TokenCache.Codeunit.al
+++ b/businessCentral/app/src/TokenCache.Codeunit.al
@@ -11,9 +11,9 @@ codeunit 82580 "ADLSE Token Cache"
         TokenExpiresAtKeyNameTok: Label 'adlse-token-expires', Locked = true;
 
     [NonDebuggable]
-    procedure GetCachedToken(): Text
+    procedure GetCachedToken(): SecretText
     var
-        Token: Text;
+        Token: SecretText;
     begin
         if not IsolatedStorage.Contains(AccessTokenKeyNameTok, DataScope::Module) then
             exit('');
@@ -38,17 +38,14 @@ codeunit 82580 "ADLSE Token Cache"
     end;
 
     [NonDebuggable]
-    procedure SetToken(Token: Text; ExpiresAt: DateTime)
+    procedure SetToken(Token: SecretText; ExpiresAt: DateTime)
     begin
-        // Clear any existing cache entries before writing to avoid "record already exists"
-        // errors from concurrent sessions. Deleting first ensures IsolatedStorage.Set always
-        // performs an INSERT on a clean state, which is safe on both SaaS and On-Premises.
         ClearCache();
         WriteToCache(Token, ExpiresAt);
     end;
 
     [NonDebuggable]
-    local procedure WriteToCache(Token: Text; ExpiresAt: DateTime)
+    local procedure WriteToCache(Token: SecretText; ExpiresAt: DateTime)
     begin
 #pragma warning disable LC0043
         IsolatedStorage.Set(AccessTokenKeyNameTok, Token, DataScope::Module);
@@ -58,7 +55,7 @@ codeunit 82580 "ADLSE Token Cache"
 
     procedure IsTokenValid(): Boolean
     begin
-        if GetCachedToken() = '' then
+        if GetCachedToken().IsEmpty() then
             exit(false);
         exit(CurrentDateTime() < GetTokenExpiry());
     end;

--- a/businessCentral/app/src/TokenCache.Codeunit.al
+++ b/businessCentral/app/src/TokenCache.Codeunit.al
@@ -16,7 +16,7 @@ codeunit 82580 "ADLSE Token Cache"
         Token: SecretText;
     begin
         if not IsolatedStorage.Contains(AccessTokenKeyNameTok, DataScope::Module) then
-            exit('');
+            exit;
 #pragma warning disable LC0043
         IsolatedStorage.Get(AccessTokenKeyNameTok, DataScope::Module, Token);
 #pragma warning restore LC0043

--- a/businessCentral/test/src/CredentialsTests.Codeunit.al
+++ b/businessCentral/test/src/CredentialsTests.Codeunit.al
@@ -181,6 +181,89 @@ codeunit 85573 "ADLSE Credentials Tests"
         LibraryAssert.AreEqual(TestSecret, ADLSECredentials2.GetClientSecret(), 'Client secret should persist');
     end;
 
+    [Test]
+    procedure TestCredentialsPersistence_AcrossInstances()
+    var
+        ADLSECredentials1: Codeunit "ADLSE Credentials";
+        ADLSECredentials2: Codeunit "ADLSE Credentials";
+        TestTenantId: Text;
+        TestClientId: Text;
+        TestSecret: Text;
+    begin
+        // [SCENARIO] Credentials persist across codeunit instances
+        // [GIVEN] Credentials set in one instance
+        Initialize();
+        TestTenantId := 'persist-tenant-' + Format(CreateGuid());
+        TestClientId := 'persist-client-' + Format(CreateGuid());
+        TestSecret := 'persist-secret-' + Format(CreateGuid());
+
+        ADLSECredentials1.SetTenantID(TestTenantId);
+        ADLSECredentials1.SetClientID(TestClientId);
+        ADLSECredentials1.SetClientSecret(TestSecret);
+
+        // [WHEN] A new instance retrieves the credentials
+        ADLSECredentials2.Init();
+
+        // [THEN] The values are the same
+        LibraryAssert.AreEqual(TestTenantId, ADLSECredentials2.GetTenantID(), 'Tenant ID should persist');
+        LibraryAssert.AreEqual(TestClientId, ADLSECredentials2.GetClientID(), 'Client ID should persist');
+        LibraryAssert.AreEqual(TestSecret, ADLSECredentials2.GetClientSecret(), 'Client secret should persist');
+    end;
+
+    [Test]
+    procedure TestSetAndGetClientCertificate()
+    var
+        ADLSECredentials: Codeunit "ADLSE Credentials";
+        TestCertificate: Text;
+    begin
+        // [SCENARIO] SetClientCertificate stores and GetClientCertificate retrieves the certificate
+        // [GIVEN] A credentials instance
+        Initialize();
+        TestCertificate := 'test-certificate-base64-' + Format(CreateGuid());
+
+        // [WHEN] SetClientCertificate is called followed by Init and GetClientCertificate
+        ADLSECredentials.SetClientCertificate(TestCertificate);
+        ADLSECredentials.Init();
+
+        // [THEN] The stored value is retrieved
+        LibraryAssert.AreEqual(TestCertificate, ADLSECredentials.GetClientCertificate(), 'Certificate should match');
+    end;
+
+    [Test]
+    procedure TestIsClientCertificateSet_WithValue_ReturnsTrue()
+    var
+        ADLSECredentials: Codeunit "ADLSE Credentials";
+    begin
+        // [SCENARIO] IsClientCertificateSet returns true when certificate is set
+        // [GIVEN] A credentials instance with a certificate set
+        Initialize();
+        ADLSECredentials.SetClientCertificate('test-cert-' + Format(CreateGuid()));
+        ADLSECredentials.Init();
+
+        // [WHEN] IsClientCertificateSet is called
+        // [THEN] Returns true
+        LibraryAssert.IsTrue(ADLSECredentials.IsClientCertificateSet(), 'IsClientCertificateSet should return true');
+    end;
+
+    [Test]
+    procedure TestSetAndGetClientCertificatePassword()
+    var
+        ADLSECredentials: Codeunit "ADLSE Credentials";
+        TestPassword: Text;
+    begin
+        // [SCENARIO] SetClientCertificatePassword stores and GetClientCertificatePassword retrieves the password
+        // [GIVEN] A credentials instance
+        Initialize();
+        TestPassword := 'test-cert-password-' + Format(CreateGuid());
+
+        // [WHEN] SetClientCertificatePassword is called followed by Init and GetClientCertificatePassword
+        ADLSECredentials.SetClientCertificatePassword(TestPassword);
+        ADLSECredentials.Init();
+
+        // [THEN] The stored value is retrieved
+        LibraryAssert.AreEqual(TestPassword, ADLSECredentials.GetClientCertificatePassword(), 'Certificate password should match');
+    end;
+
     local procedure Initialize()
     var
         LibraryTestInitialize: Codeunit "Library - Test Initialize";


### PR DESCRIPTION
## Why

Some organizations require stronger authentication than a client secret for Azure AD app registrations. This adds support for the OAuth2 certificate credentials flow, letting users authenticate with a PFX certificate and password instead of a client secret. Closes #513.

## What changed

A new **Use Certificate Authentication** toggle on the Setup page switches the entire auth flow. When enabled:

- The Client Secret field is hidden; Certificate (Base64 PFX) and Certificate Password fields are shown instead.
- On every token request, a RS256-signed JWT assertion is built from the certificate's private key and sent to Azure AD as `client_assertion` (`grant_type=client_credentials`).
- The certificate and its password are stored in `IsolatedStorage` (scope `Module`) using the same isolation pattern as the existing client secret.

### Key design decisions

- **Boolean vs. enum** - a simple boolean `Use Certificate Authentication` (field 105) keeps backward compatibility and avoids an unnecessary enum object.
- **Native BC crypto APIs** - `X509Certificate2`, `RSACryptoServiceProvider`, and `Base64Convert` are used directly (BC platform v28, runtime 17, Cloud target) with no .NET DotNet interop.
- **JWT x5t thumbprint** - the hex SHA-1 thumbprint from `GetCertificateThumbprint` is converted to base64url via a `TempBlob` byte stream (`HexToBase64Url`).
- **Token caching** - existing `ADLSETokenCache` is reused unchanged; cert-based tokens are cached the same way as secret-based tokens.

### Files changed

| File | Change |
|---|---|
| `Setup.Table.al` | New boolean field 105 `Use Certificate Authentication` (default false) |
| `Credentials.Codeunit.al` | Certificate + password IsolatedStorage; 5 new Get/Set/Is methods; updated `Init()` and `Check()` |
| `Http.Codeunit.al` | `BuildCertificateTokenRequestBody()` with RS256 JWT signing; branched `AcquireTokenOAuth2()`; `Base64UrlEncode` / `HexToBase64Url` helpers |
| `Setup.Page.al` | Conditional UI: Client Secret hidden when cert auth on; Certificate and Password fields shown |
| `CredentialsTests.Codeunit.al` | 4 new tests for certificate credential get/set/persist/check |

## Areas to review carefully

- `HexToBase64Url` writes individual bytes via `OutStream.Write(ByteVal, 1)` - please verify this correctly serializes each byte on the target BC runtime.
- `RSACryptoServiceProvider.SignData` call signature - the key is loaded via `FromXmlString` before calling `SignData`; if the platform API differs, the parameter order may need adjusting.