### PR TITLE
Fix NavEncryptionKeyNotFoundException on setup page open

### DIFF
--- a/businessCentral/app/src/Credentials.Codeunit.al
+++ b/businessCentral/app/src/Credentials.Codeunit.al
@@ -151,7 +151,15 @@ codeunit 82565 "ADLSE Credentials"
     begin
         if not IsolatedStorage.Contains(KeyName, IsolatedStorageDataScope()) then
             exit('');
-#pragma warning disable LC0043            
+        if not TryGetSecret(KeyName, Secret) then
+            Secret := '';
+    end;
+
+    [NonDebuggable]
+    [TryFunction]
+    local procedure TryGetSecret(KeyName: Text; var Secret: Text)
+    begin
+#pragma warning disable LC0043
         IsolatedStorage.Get(KeyName, IsolatedStorageDataScope(), Secret);
 #pragma warning restore LC0043
     end;


### PR DESCRIPTION
## Problem

When a stored credential (client secret, tenant ID, etc.) was originally saved with encryption enabled, and the encryption key is later unavailable -- for example after a key rotation or when a client secret expires and is re-entered -- opening the ADLSE Setup page would crash with:

> `NavEncryptionKeyNotFoundException` in `ADLSE Credentials.GetSecret`

This prevented users from even reaching the setup page to enter new credentials.

## Solution

Split the `IsolatedStorage.Get` call in `GetSecret` into a separate `[TryFunction]` procedure (`TryGetSecret`). If the underlying get throws (e.g. encryption key not found), the try function returns `false` and `GetSecret` returns an empty string instead of propagating the exception.

The setup page can now open normally with empty credential fields, allowing the user to re-enter their credentials without error.

## Changes

- `businessCentral/app/src/Credentials.Codeunit.al`
  - Extracted `IsolatedStorage.Get` into a new `[TryFunction]` `TryGetSecret`
  - `GetSecret` now uses `if not TryGetSecret(...)` to handle failures gracefully