### PR TITLE
Add OnAfterSetStateFinished event and change access to internal

### DIFF
--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -381,6 +381,8 @@ codeunit 82561 "ADLSE Execute"
             if EmitTelemetry then
                 ADLSEExecution.Log('ADLSE-041', 'All exports are finished', Verbosity::Normal);
         end;
+
+        OnAfterSetStateFinished(ADLSETable, TableCaption);
     end;
 
     procedure UpdateInProgressTableTimestamp(var Rec: Record "ADLSE Table"; LastTimestamp: BigInteger; Deletes: Boolean)
@@ -463,4 +465,8 @@ codeunit 82561 "ADLSE Execute"
         ADLSECommunication.UpdateCdmJsons(EntityJsonNeedsUpdate, ManifestJsonsNeedsUpdate);
     end;
 
+    [IntegrationEvent(false, false)]
+    internal procedure OnAfterSetStateFinished(var ADLSETable: Record "ADLSE Table"; TableCaption: Text)
+    begin
+    end;
 }

--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -3,7 +3,6 @@
 namespace bc2adls;
 codeunit 82561 "ADLSE Execute"
 {
-    Access = Internal;
     TableNo = "ADLSE Table";
     Permissions = tabledata "ADLSE Table" = rm;
 
@@ -127,7 +126,7 @@ codeunit 82561 "ADLSE Execute"
         ExportTableDeletes(TableID, ADLSECommunicationDeletions, DeletedLastEntryNo, DidUpserts);
     end;
 
-    procedure UpdatedRecordsExist(TableID: Integer; UpdatedLastTimeStamp: BigInteger): Boolean
+    internal procedure UpdatedRecordsExist(TableID: Integer; UpdatedLastTimeStamp: BigInteger): Boolean
     var
         ADLSESeekData: Report "ADLSE Seek Data";
         RecordRef: RecordRef;
@@ -238,7 +237,7 @@ codeunit 82561 "ADLSE Execute"
             ADLSEExecution.Log('ADLSE-009', 'Updated records exported', Verbosity::Normal);
     end;
 
-    procedure DeletedRecordsExist(TableID: Integer; DeletedLastEntryNo: BigInteger): Boolean
+    internal procedure DeletedRecordsExist(TableID: Integer; DeletedLastEntryNo: BigInteger): Boolean
     var
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
         ADLSESeekData: Report "ADLSE Seek Data";
@@ -308,7 +307,7 @@ codeunit 82561 "ADLSE Execute"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Deleted Record", 'rd')]
-    procedure FixDeletedRecordThatAreInTable(var ADLSEDeletedRecord: Record "ADLSE Deleted Record")
+    internal procedure FixDeletedRecordThatAreInTable(var ADLSEDeletedRecord: Record "ADLSE Deleted Record")
     var
         RecordRef: RecordRef;
     begin
@@ -328,7 +327,7 @@ codeunit 82561 "ADLSE Execute"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'r')]
-    procedure CreateFieldListForTable(TableID: Integer) FieldIdList: List of [Integer]
+    internal procedure CreateFieldListForTable(TableID: Integer) FieldIdList: List of [Integer]
     var
         ADLSEField: Record "ADLSE Field";
         ADLSEUtil: Codeunit "ADLSE Util";
@@ -385,7 +384,7 @@ codeunit 82561 "ADLSE Execute"
         OnAfterSetStateFinished(ADLSETable, TableCaption);
     end;
 
-    procedure UpdateInProgressTableTimestamp(var Rec: Record "ADLSE Table"; LastTimestamp: BigInteger; Deletes: Boolean)
+    internal procedure UpdateInProgressTableTimestamp(var Rec: Record "ADLSE Table"; LastTimestamp: BigInteger; Deletes: Boolean)
     var
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         ADLSEExecution: Codeunit "ADLSE Execution";
@@ -422,7 +421,7 @@ codeunit 82561 "ADLSE Execute"
         Commit(); // to save the last time stamps into the database.
     end;
 
-    procedure ExportSchema(tableId: Integer)
+    internal procedure ExportSchema(tableId: Integer)
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";


### PR DESCRIPTION
This pull request updates the `codeunit 82561 "ADLSE Execute"` to improve encapsulation and extensibility. The main focus is on tightening the access level of procedures to `internal` and introducing a new integration event for extensibility.

**Access Control Improvements:**

* Changed the access modifier of multiple procedures from public to `internal`, restricting their use to within the same module. This affects procedures such as `UpdatedRecordsExist`, `DeletedRecordsExist`, `FixDeletedRecordThatAreInTable`, `CreateFieldListForTable`, `UpdateInProgressTableTimestamp`, and `ExportSchema`. [[1]](diffhunk://#diff-a65a779a0a57ded94823d28e935e3a702319de35fdfa84ab1b10462bcd5ef9a7L130-R129) [[2]](diffhunk://#diff-a65a779a0a57ded94823d28e935e3a702319de35fdfa84ab1b10462bcd5ef9a7L241-R240) [[3]](diffhunk://#diff-a65a779a0a57ded94823d28e935e3a702319de35fdfa84ab1b10462bcd5ef9a7L311-R310) [[4]](diffhunk://#diff-a65a779a0a57ded94823d28e935e3a702319de35fdfa84ab1b10462bcd5ef9a7L331-R330) [[5]](diffhunk://#diff-a65a779a0a57ded94823d28e935e3a702319de35fdfa84ab1b10462bcd5ef9a7R383-R387) [[6]](diffhunk://#diff-a65a779a0a57ded94823d28e935e3a702319de35fdfa84ab1b10462bcd5ef9a7L423-R424)

**Extensibility Enhancements:**

* Added a new integration event, `OnAfterSetStateFinished`, which is raised after the export process completes. This allows other extensions or modules to react to the completion of the export process. [[1]](diffhunk://#diff-a65a779a0a57ded94823d28e935e3a702319de35fdfa84ab1b10462bcd5ef9a7R383-R387) [[2]](diffhunk://#diff-a65a779a0a57ded94823d28e935e3a702319de35fdfa84ab1b10462bcd5ef9a7R467-R470)

**Other Minor Changes:**

* Removed the `Access = Internal;` property from the codeunit declaration, as it is now redundant given the internal access of the procedures.