### PR TITLE
Fix: table reset no longer re-enables disabled tables

### DIFF
--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -246,10 +246,6 @@ table 82561 "ADLSE Table"
     begin
         if Rec.FindSet(true) then
             repeat
-                if not Rec.Enabled then begin
-                    Rec.Enabled := true;
-                    Rec.Modify(true);
-                end;
                 ADLSESetup.GetSingleton();
 
                 if not AllCompanies then begin
@@ -277,8 +273,6 @@ table 82561 "ADLSE Table"
 
                 if (ADLSESetup."Delete Table") then
                     ADLSECommunication.ResetTableExport(Rec."Table ID", AllCompanies);
-
-                Rec.Modify(true);
 
                 OnAfterResetSelected(Rec);
 


### PR DESCRIPTION
## Problem

When performing a table reset, all previously disabled tables were automatically re-enabled (the `Enabled` checkbox became active again), even for tables that were intentionally configured as disabled prior to the reset.

This added overhead after each reset and introduced a risk of unintended data extraction.

Fixes #530

## Root Cause

In `Table.Table.al`, the `ResetSelected()` procedure contained a block that unconditionally set `Rec.Enabled := true` for any disabled table:

```al
if not Rec.Enabled then begin
    Rec.Enabled := true;
    Rec.Modify(true);
end;
```

## Fix

- Removed the block that re-enables disabled tables during reset
- Removed the orphaned `Rec.Modify(true)` call (no fields on `Rec` are changed during the reset loop anymore)

The reset now only clears export state (timestamps and deleted records) without touching the `Enabled` flag — disabled tables stay disabled.