### PR TITLE
Fix: delete tables from multi-company config screen

### DIFF
--- a/businessCentral/app/src/CompanySetupTables.Page.al
+++ b/businessCentral/app/src/CompanySetupTables.Page.al
@@ -128,8 +128,9 @@ page 82565 "ADLSE Company Setup Tables"
                 var
                     ADLSETable: Record "ADLSE Table";
                 begin
-                    ADLSETable.Get(Rec."Table ID");
-                    ADLSETable.Delete(true);
+                    Rec.Delete(true);
+                    if ADLSETable.Get(Rec."Table ID") then
+                        ADLSETable.Delete(true);
                     CurrPage.Update();
                 end;
             }


### PR DESCRIPTION
When trying to delete a table from the "ADLSE Company Setup Tables" page, users received the error:

> The ADL Table does not exist. Identification fields and values: Table ID='3'

The `DeleteTable` action was calling `ADLSETable.Get(Rec."Table ID")` unconditionally, but `Rec` is sourced from `ADLSE Companies Table` -- a different table than `ADLSE Table`. If the global `ADLSE Table` record was absent or never created for that table ID, the `Get` call would throw instead of deleting anything.

The fix deletes `Rec` (the `ADLSE Companies Table` row) directly, then conditionally also deletes from `ADLSE Table` when a matching record exists. This preserves the cascade cleanup of fields/timestamps/deleted records that `ADLSE Table.OnDelete()` performs, while no longer erroring when the global record is missing.

Fixes: #535