### PR TITLE
fix: batch deletes in ClearTrackedDeletions to prevent SQL timeout

### DIFF
--- a/businessCentral/app/src/ClearTrackedDeletions.Codeunit.al
+++ b/businessCentral/app/src/ClearTrackedDeletions.Codeunit.al
@@ -24,20 +24,41 @@ codeunit 82573 "ADLSE Clear Tracked Deletions"
     var
         ADLSETable: Record "ADLSE Table";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
-        ADLSEDeletedRecord: Record "ADLSE Deleted Record";
+        LastEntryNo: BigInteger;
     begin
         ADLSETable.SetLoadFields("Table ID");
         if ADLSETable.FindSet() then
             repeat
-                ADLSEDeletedRecord.SetRange("Table ID", ADLSETable."Table ID");
-                ADLSEDeletedRecord.SetFilter("Entry No.", '<=%1', ADLSETableLastTimestamp.GetDeletedLastEntryNo(ADLSETable."Table ID"));
-                if not ADLSEDeletedRecord.IsEmpty() then
-                    ADLSEDeletedRecord.DeleteAll(false);
-
+                LastEntryNo := ADLSETableLastTimestamp.GetDeletedLastEntryNo(ADLSETable."Table ID");
+                DeleteInBatches(ADLSETable."Table ID", LastEntryNo);
                 ADLSETableLastTimestamp.SaveDeletedLastEntryNo(ADLSETable."Table ID", 0);
-
-                Commit(); //Because of very large numbers of records, we commit after each table.
+                Commit();
             until ADLSETable.Next() = 0;
         Message(TrackedDeletedRecordsRemovedMsg);
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Deleted Record", 'rd')]
+    local procedure DeleteInBatches(TableID: Integer; LastEntryNo: BigInteger)
+    var
+        ADLSEDeletedRecord: Record "ADLSE Deleted Record";
+        BatchUpperBound: Integer;
+        BatchSize: Integer;
+    begin
+        BatchSize := 1000;
+        // Use Key2 (Table ID) to efficiently seek records for this table.
+        // FindFirst returns the record with the lowest Entry No. for this Table ID
+        // because Entry No. is the clustered key and acts as the row locator in Key2.
+        ADLSEDeletedRecord.SetRange("Table ID", TableID);
+        ADLSEDeletedRecord.SetFilter("Entry No.", '<=%1', LastEntryNo);
+        while ADLSEDeletedRecord.FindFirst() do begin
+            BatchUpperBound := ADLSEDeletedRecord."Entry No." + BatchSize - 1;
+            ADLSEDeletedRecord.SetRange("Entry No.", ADLSEDeletedRecord."Entry No.", BatchUpperBound);
+            ADLSEDeletedRecord.DeleteAll(false);
+            Commit();
+            // Restore the Table ID range and Entry No. upper-bound filter for next iteration.
+            ADLSEDeletedRecord.SetRange("Entry No.");
+            ADLSEDeletedRecord.SetRange("Table ID", TableID);
+            ADLSEDeletedRecord.SetFilter("Entry No.", '<=%1', LastEntryNo);
+        end;
     end;
 }


### PR DESCRIPTION
## Why

The `ADLSE Clear Tracked Deletions` job fails with a SQL command timeout when the `ADLSE Deleted Record` table has grown very large (e.g. 246 million rows). The original code called `DeleteAll(false)` once per tracked table in a single transaction, which exceeds the SQL timeout at that scale. Because the timeout rolls back the entire transaction, the job makes zero progress on each run and the table grows unbounded.

## What changed

`ClearTrackedDeletedRecords` now delegates to a new `DeleteInBatches` procedure that breaks the work into transactions of at most 1,000 rows:

- Filters records for the current table using `SetRange("Table ID")` so Key2 (the Table ID non-clustered index) is used for efficient seeks.
- Each loop iteration calls `FindFirst` to get the lowest `Entry No.` still remaining, sets a range of `[firstEntryNo, firstEntryNo + 999]`, calls `DeleteAll(false)`, and commits.
- Repeats until no records remain for the table, then saves the timestamp and does a final `Commit()` as before.

No table schema changes are required. The fix is fully backwards-compatible: small tables complete in a single loop iteration just as before, and large tables now make incremental, committed progress that survives across job queue runs.

Fixes: #564