### PR TITLE
fix: handle empty table exports for Open Mirroring with header-only CSV

### DIFF
--- a/businessCentral/app/src/Communication.Codeunit.al
+++ b/businessCentral/app/src/Communication.Codeunit.al
@@ -335,6 +335,19 @@ codeunit 82562 "ADLSE Communication"
         LastDeletedEntryNoExported := LastFlushedDeletedEntryNo;
     end;
 
+    [TryFunction]
+    procedure TryExportEmptyFullLoad()
+    var
+        ADLSEUtil: Codeunit "ADLSE Util";
+        RecordRef: RecordRef;
+    begin
+        // Writes a header-only CSV so Fabric Open Mirroring receives a snapshot file even for tables without records.
+        ClearLastError();
+        RecordRef.Open(TableID);
+        Payload.Append(ADLSEUtil.CreateCsvHeader(RecordRef, FieldIdList));
+        FlushPayload();
+    end;
+
     local procedure Finish() LastTimestampExported: BigInteger
     var
         ADLSESetup: Record "ADLSE Setup";

--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -153,6 +153,16 @@ codeunit 82561 "ADLSE Execute"
             ADLSECommunicationDeletions.Init(TableID, FieldIdList, DeletedLastEntryNo, EmitTelemetry);
             // entity has been already checked above
             ExportTableDeletes(TableID, ADLSECommunicationDeletions, DeletedLastEntryNo, DidUpserts, DidDeletes, true);
+
+            // A table that is empty on its initial export never produces a CSV file, so Fabric Open Mirroring never
+            // sees it leave the "Snapshotting" state and eventually marks it as failed. Write a header-only file instead.
+            if (ADLSESetup.GetStorageType() = ADLSESetup."Storage Type"::"Open Mirroring")
+                and (UpdatedLastTimeStamp = 0) and not DidUpserts and not DidDeletes
+            then
+                if not ADLSECommunication.TryExportEmptyFullLoad() then begin
+                    ErrorMessage.Message := StrSubstNo('%1%2', GetLastErrorText(), GetLastErrorCallStack());
+                    Error(ErrorMessage);
+                end;
         end;
     end;
 

--- a/businessCentral/app/src/SessionManager.Codeunit.al
+++ b/businessCentral/app/src/SessionManager.Codeunit.al
@@ -17,7 +17,9 @@ codeunit 82570 "ADLSE Session Manager"
     procedure StartExport(TableID: Integer; EmitTelemetry: Boolean): Boolean
     begin
         // if the last run failed, ensure that you run again, even though there may be no data differences.
-        exit(StartExport(TableID, false, LastRunFailed(TableID, EmitTelemetry), EmitTelemetry));
+        // Also force the very first run for Open Mirroring, since an empty table would otherwise never get a session
+        // (DataChangesExist stays false forever), and would never receive its initial (header-only) snapshot file.
+        exit(StartExport(TableID, false, LastRunFailed(TableID, EmitTelemetry) or NeverRunOnOpenMirroring(TableID), EmitTelemetry));
     end;
 
     local procedure StartExportFromPending(TableID: Integer; EmitTelemetry: Boolean): Boolean
@@ -106,6 +108,22 @@ codeunit 82570 "ADLSE Session Manager"
             CustomDimensions.Add('Entity', ADLSEUtil.GetTableCaption(TableID));
             ADLSEExecution.Log('ADLSE-027', 'Last run failed.', Verbosity::Normal, CustomDimensions);
         end;
+    end;
+
+    local procedure NeverRunOnOpenMirroring(TableID: Integer): Boolean
+    var
+        ADLSESetup: Record "ADLSE Setup";
+        ADLSERun: Record "ADLSE Run";
+        Status: Enum "ADLSE Run State";
+        StartedAt: DateTime;
+        Error: Text[2048];
+    begin
+        ADLSESetup.GetSingleton();
+        if ADLSESetup.GetStorageType() <> ADLSESetup."Storage Type"::"Open Mirroring" then
+            exit(false);
+
+        ADLSERun.GetLastRunDetails(TableID, Status, StartedAt, Error);
+        exit(Status = "ADLSE Run State"::None);
     end;
 
     procedure StartExportFromPendingTables()


### PR DESCRIPTION
Fixes issue #566 