### PR TITLE
Fix Open Mirroring Reset not clearing timestamp for non-per-company tables

### DIFF
--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -250,7 +250,7 @@ table 82561 "ADLSE Table"
 
                 if not AllCompanies then begin
                     if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then begin
-                        if ADLSETableLastTimestamp.Get(CompanyName(), Rec."Table ID") then
+                        if ADLSETableLastTimestamp.Get(ADLSETableLastTimestamp.GetCompanyNameToLookFor(Rec."Table ID"), Rec."Table ID") then
                             ADLSETableLastTimestamp.Delete(true);
                     end
                     else begin

--- a/businessCentral/app/src/TableLastTimestamp.Table.al
+++ b/businessCentral/app/src/TableLastTimestamp.Table.al
@@ -208,7 +208,7 @@ table 82564 "ADLSE Table Last Timestamp"
             Rec."Deleted Last Entry No." := Timestamp;
     end;
 
-    local procedure GetCompanyNameToLookFor(TableID: Integer): Text
+    internal procedure GetCompanyNameToLookFor(TableID: Integer): Text
     var
         ADLSEUtil: Codeunit "ADLSE Util";
     begin

--- a/businessCentral/test/src/DeleteTests.Codeunit.al
+++ b/businessCentral/test/src/DeleteTests.Codeunit.al
@@ -183,6 +183,33 @@ codeunit 85563 "ADLSE Delete Tests"
         RecordRef.Close();
     end;
 
+    [Test]
+    [HandlerFunctions('MessageHandler')]
+    procedure ResetSelectedClearsTimestampForNonPerCompanyTableInOpenMirroring()
+    var
+        ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
+    begin
+        // [SCENARIO 576] For a non-DataPerCompany table (e.g. User) in Open Mirroring, ResetSelected(false)
+        // (the path used by the API "Reset" action) must clear the last-timestamp record, which is stored
+        // under a blank company name, not the current company.
+        // [GIVEN] Open Mirroring setup
+        Initialize();
+        ADLSELibrarybc2adls.CleanUp();
+        ADLSELibrarybc2adls.CreateAdlseSetup("Storage Type"::"Open Mirroring");
+
+        // [GIVEN] The User table (non-per-company) is added for export and has a last exported timestamp
+        ADLSETable.Add(Database::User);
+        ADLSETableLastTimestamp.SaveUpdatedLastTimestamp(Database::User, 123456789);
+        LibraryAssert.IsTrue(ADLSETableLastTimestamp.ExistsUpdatedLastTimestamp(Database::User), 'Last timestamp should exist before reset');
+
+        // [WHEN] ResetSelected is called without AllCompanies (the API "Reset" action default)
+        ADLSETable.Get(Database::User);
+        ADLSETable.ResetSelected();
+
+        // [THEN] The last-timestamp record for the table is cleared
+        LibraryAssert.IsFalse(ADLSETableLastTimestamp.ExistsUpdatedLastTimestamp(Database::User), 'Last timestamp should be cleared after reset');
+    end;
+
     local procedure InsertPaymentTerms(var PaymentTerms: Record "Payment Terms")
     begin
         PaymentTerms.Init();


### PR DESCRIPTION
## Why

For a non-DataPerCompany table (e.g. `User`, table 2000000120) in Open Mirroring, calling `Reset` deleted the table from the landing zone but left its last exported timestamp untouched. The next export then found no changes and skipped the table entirely, leaving an empty, never-re-exported table in the mirrored database.

## Root cause

`ADLSE Table.ResetSelected(AllCompanies: Boolean)` has an `AllCompanies = false` branch for Open Mirroring that looked up the timestamp record with `Get(CompanyName(), TableID)`. Non-DataPerCompany tables store this record under a **blank** company name instead (`ADLSE Table Last Timestamp.GetCompanyNameToLookFor`), so the lookup never found the record and it was never deleted.

This branch is reached whenever `ResetSelected()` (its no-arg overload, defaulting to `AllCompanies = false`) is called for Open Mirroring - notably by the API action `Reset` on `adlseTables` (`TableApiv12.Page.al`). The UI Reset action always forces `AllCompanies = true` for Open Mirroring, which uses a different (correct) `DeleteAll` branch, so the bug was only visible through the API.

## Fix

- Changed the lookup in `ResetSelected` to use `ADLSETableLastTimestamp.GetCompanyNameToLookFor(TableID)` instead of `CompanyName()`, matching how the record is written.
- Exposed `GetCompanyNameToLookFor` as `internal` (was `local`) so it can be called from `Table.Table.al`.

This fixes the shared logic that both the API and UI Reset paths funnel through, so no changes were needed to the API page itself, and behavior for other storage types (Azure Data Lake / Fabric) and DataPerCompany tables is unaffected.

## Tests

Added `ResetSelectedClearsTimestampForNonPerCompanyTableInOpenMirroring` in `DeleteTests.Codeunit.al`, which reproduces the API scenario (User table, Open Mirroring, `ResetSelected()` default) and asserts the timestamp record is cleared after reset.

Fixes: #576